### PR TITLE
Add a screenshot to the intro Options section

### DIFF
--- a/source/config/configuration.rst
+++ b/source/config/configuration.rst
@@ -78,6 +78,9 @@ The option settings are found under the :menuselection:`"Options --> Options..."
 a new window with the option groups listed in a tree format on the left hand side, and the individual
 settings on the right hand side.  This is where the majority of Picard's customization is performed.
 
+.. image:: ../images/options-general.png
+   :width: 100 %
+
 .. only:: html
 
    .. seealso::


### PR DESCRIPTION
### Summary

This is a…

- [ ] Correction
- [ ] Addition
- [ ] Restructuring
- [x] Minor / simple change (like a typo)
- [ ] Other

### Description of the Change

Give a little more context to the Options intro by repeating an existing screenshot.