### PR TITLE
Update options for Picard 2.5

### DIFF
--- a/source/config/options_cover_art_providers.rst
+++ b/source/config/options_cover_art_providers.rst
@@ -33,9 +33,9 @@ are queried. Picard will try the providers from top to bottom until an image is 
    care more about visual quality then having an exact representation of your release. It is also a good
    fallback for the Cover Art Archive provider.
 
-**Sites on the whitelist**
+**Allowed cover art URLs**
 
-   This will use images provided from whitelisted sites. See `Cover art whitelist
+   This will use images provided from approved third-party sites. See `Cover art whitelist
    <https://wiki.musicbrainz.org/History:Style/Relationships/URLs/Cover_art_whitelist>`_ in the Style Guide
    for more information.
 

--- a/source/config/options_interface.rst
+++ b/source/config/options_interface.rst
@@ -18,6 +18,20 @@ User Interface Options
     If this option is disabled, the text labels under the icons in the toolbar will not be displayed,
     causing the toolbar to appear a little smaller.
 
+**Use system theme**
+
+    By default Picard uses the Qt Fusion theme for the user interface. If you enable this option
+    Picard will instead use the default Qt theme configured on your system. How to change the Qt
+    theme depends on your desktop environment.
+
+    .. note::
+        This option is not available on Windows and macOS.
+
+    .. warning::
+
+        Please be aware that using the system theme might cause the user interface to be not shown correctly.
+        If this is the case disable the "Use system theme" option to use Picard\'s default theme again.
+
 **Allow selection of multiple directories**
 
     Enabling this option will bypass the native directory selector and use Qt's file dialog.  This
@@ -28,7 +42,8 @@ User Interface Options
 **Use built-in search rather than looking in browser**
 
     When this option is enabled the search for albums, artists or tracks will show the results in a dialog.
-    By default this option is disabled and Picard will open a search on MusicBrainz.org in your default web browser.
+    By default this option is enabled. If this option is disabled Picard will open a search on
+    MusicBrainz.org in your default web browser.
 
 **Use advanced query syntax**
 

--- a/source/config/options_interface.rst
+++ b/source/config/options_interface.rst
@@ -30,7 +30,7 @@ User Interface Options
     .. warning::
 
         Please be aware that using the system theme might cause the user interface to be not shown correctly.
-        If this is the case disable the "Use system theme" option to use Picard\'s default theme again.
+        If this is the case disable the "Use system theme" option to use Picard's default theme again.
 
 **Allow selection of multiple directories**
 

--- a/source/config/options_network.rst
+++ b/source/config/options_network.rst
@@ -15,8 +15,14 @@ Network
 
 **Web Proxy**
 
-    If you need a proxy to make an outside network connection you may specify one here.  The required
-    settings are **Server Address**, **Port**, **Username** and **Password**.
+    If you need a proxy to make an outside network connection you may specify one here.  You can
+    choose between HTTP and SOCKS proxy.  The required settings are **Server Address**, **Port**.
+    If the proxy requires authentication also enter **Username** and **Password**.
+
+**Request timeout in seconds**
+
+    By default Picard will abort running network requests after 30 seconds of inactivity.  If needed
+    you can change the timeout period here.
 
 .. |lookup_tagger| image:: ../images/mblookup-tagger.png
    :height: 1em

--- a/source/config/options_network.rst
+++ b/source/config/options_network.rst
@@ -16,7 +16,7 @@ Network
 **Web Proxy**
 
     If you need a proxy to make an outside network connection you may specify one here.  You can
-    choose between HTTP and SOCKS proxy.  The required settings are **Server Address**, **Port**.
+    choose between HTTP and SOCKS proxy.  The required settings are **Server Address** and **Port**.
     If the proxy requires authentication also enter **Username** and **Password**.
 
 **Request timeout in seconds**


### PR DESCRIPTION
<!--
    Thank-you for submitting a pull request. Your effort and input is appreciated.

    Please use this template to help us review your change. Not everything is
    required for every change, so please feel free to omit any sections that
    are not relevant to your change.

    Also, please ensure that you've reviewed the guidelines in CONTRIBUTING.md.
-->

### Summary

This is a…

- [ ] Correction
- [x] Addition
- [ ] Restructuring
- [ ] Minor / simple change (like a typo)
- [ ] Other

### Reason for the Change

There have been several changes in the options for Picard 2.5:

- Support for SOCKS proxy
- Support for configuring a network timeout
- Cover art provider for approved URLs has been renamed for clarity (we probably could also remove it, but let's do this for a later time)
- Option to use system theme
- Built-in search is the new default