### PR TITLE
Picard 2.5 small UI additions

### DIFF
--- a/source/config/configuration.rst
+++ b/source/config/configuration.rst
@@ -23,8 +23,12 @@ item, simply check the box for the screen option.  The items are:
 **File Browser**
 
    This displays a file browser on the left side of the screen for selecting
-   files and directories for processing.  Files and directories can also be selected using your
-   system's file browser by dragging and dropping them onto the Picard application.
+   files and directories for processing. Files can be loaded into Picard by dragging and dropping
+   them to the right panes, double clicking on individual files or by selecting multiple files
+   and folders and selecting "Load selected files" from the context menu.
+
+   Files and directories can also be selected using your system's file browser by dragging and
+   dropping them onto the Picard application.
 
 **Cover Art**
 

--- a/source/usage/coverart.rst
+++ b/source/usage/coverart.rst
@@ -22,7 +22,10 @@ Cover Art image.
 .. image:: ../images/drop-cover-art.png
    :width: 100 %
 
-Right-clicking on the images brings up a menu of options including "Show more details", "Keep original cover
+You can also choose a local file as cover art by right clicking on the image and selecting
+"Choose local file…" from the menu.
+
+The menu also provides additional options including "Show more details", "Keep original cover
 art", and options for the way that images dropped onto the selection are processed.  Selecting "Show more
 details" will bring up a new window as:
 


### PR DESCRIPTION
<!--
    Thank-you for submitting a pull request. Your effort and input is appreciated.

    Please use this template to help us review your change. Not everything is
    required for every change, so please feel free to omit any sections that
    are not relevant to your change.

    Also, please ensure that you've reviewed the guidelines in CONTRIBUTING.md.
-->

### Summary

Document small additions to the UI in 2.5:

- Manual selection of cover art via file open dialog
- Context menu entry and double click for loading files from file browser