### PR TITLE
Add RIFF INFO to tag mapping

### DIFF
--- a/source/technical/tag_mapping_common.txt
+++ b/source/technical/tag_mapping_common.txt
@@ -24,6 +24,7 @@ AcoustID
    "APEv2", "``ACOUSTID_ID``"
    "iTunes MP4", "``----:com.apple.iTunes:Acoustid Id``"
    "ASF/Windows Media", "``Acoustid/Id``"
+   "RIFF INFO", "n/a"
 
 
 AcoustID Fingerprint
@@ -38,6 +39,7 @@ AcoustID Fingerprint
    "APEv2", "``ACOUSTID_FINGERPRINT``"
    "iTunes MP4", "``----:com.apple.iTunes:Acoustid Fingerprint``"
    "ASF/Windows Media", "``Acoustid/Fingerprint``"
+   "RIFF INFO", "n/a"
 
 
 `Album <https://musicbrainz.org/doc/Release_Title>`_
@@ -52,6 +54,7 @@ AcoustID Fingerprint
    "APEv2", "``Album``"
    "iTunes MP4", "``©alb``"
    "ASF/Windows Media", "``WM/AlbumTitle``"
+   "RIFF INFO", "``IPRD``"
 
 
 `Album Artist <https://musicbrainz.org/doc/Release_Artist>`_
@@ -66,6 +69,7 @@ AcoustID Fingerprint
    "APEv2", "``Album Artist``"
    "iTunes MP4", "``aART``"
    "ASF/Windows Media", "``WM/AlbumArtist``"
+   "RIFF INFO", "n/a"
 
 
 Album Artist Sort Order
@@ -80,6 +84,7 @@ Album Artist Sort Order
    "APEv2", "``ALBUMARTISTSORT``"
    "iTunes MP4", "``soaa``"
    "ASF/Windows Media", "``WM/AlbumArtistSortOrder``"
+   "RIFF INFO", "n/a"
 
 
 Album Sort Order [#f4]_
@@ -94,6 +99,7 @@ Album Sort Order [#f4]_
    "APEv2", "``ALBUMSORT``"
    "iTunes MP4", "``soal``"
    "ASF/Windows Media", "``WM/AlbumSortOrder``"
+   "RIFF INFO", "n/a"
 
 
 `Arranger <https://musicbrainz.org/relationship/22661fb8-cdb7-4f67-8385-b2a8be6c9f0d>`_
@@ -108,6 +114,7 @@ Album Sort Order [#f4]_
    "APEv2", "``Arranger``"
    "iTunes MP4", "n/a"
    "ASF/Windows Media", "n/a"
+   "RIFF INFO", "n/a"
 
 
 `Artist <https://musicbrainz.org/doc/Artist>`_
@@ -122,6 +129,7 @@ Album Sort Order [#f4]_
    "APEv2", "``Artist``"
    "iTunes MP4", "``©ART``"
    "ASF/Windows Media", "``Author``"
+   "RIFF INFO", "``IART``"
 
 
 Artist Sort Order
@@ -136,6 +144,7 @@ Artist Sort Order
    "APEv2", "``ARTISTSORT``"
    "iTunes MP4", "``soar``"
    "ASF/Windows Media", "``WM/ArtistSortOrder``"
+   "RIFF INFO", "n/a"
 
 
 Artists
@@ -150,6 +159,7 @@ Artists
    "APEv2", "``Artists``"
    "iTunes MP4", "``----:com.apple.iTunes:ARTISTS``"
    "ASF/Windows Media", "``WM/ARTISTS``"
+   "RIFF INFO", "n/a"
 
 
 `ASIN <https://musicbrainz.org/doc/ASIN>`_
@@ -164,6 +174,7 @@ Artists
    "APEv2", "``ASIN``"
    "iTunes MP4", "``----:com.apple.iTunes:ASIN``"
    "ASF/Windows Media", "``ASIN``"
+   "RIFF INFO", "n/a"
 
 
 `Barcode <https://musicbrainz.org/doc/Barcode>`_
@@ -178,6 +189,7 @@ Artists
    "APEv2", "``Barcode``"
    "iTunes MP4", "``----:com.apple.iTunes:BARCODE``"
    "ASF/Windows Media", "``WM/Barcode``"
+   "RIFF INFO", "n/a"
 
 
 BPM [#f4]_
@@ -192,6 +204,7 @@ BPM [#f4]_
    "APEv2", "``BPM``"
    "iTunes MP4", "``tmpo``"
    "ASF/Windows Media", "``WM/BeatsPerMinute``"
+   "RIFF INFO", "n/a"
 
 
 `Catalog Number <https://musicbrainz.org/doc/Release_Catalog_Number>`_
@@ -206,6 +219,7 @@ BPM [#f4]_
    "APEv2", "``CatalogNumber``"
    "iTunes MP4", "``----:com.apple.iTunes:CATALOGNUMBER``"
    "ASF/Windows Media", "``WM/CatalogNo``"
+   "RIFF INFO", "n/a"
 
 
 Comment [#f4]_
@@ -220,6 +234,7 @@ Comment [#f4]_
    "APEv2", "``Comment``"
    "iTunes MP4", "``©cmt``"
    "ASF/Windows Media", "``Description``"
+   "RIFF INFO", "``ICMT``"
 
 
 Compilation (iTunes) [#f5]_
@@ -234,6 +249,7 @@ Compilation (iTunes) [#f5]_
    "APEv2", "``Compilation``"
    "iTunes MP4", "``cpil``"
    "ASF/Windows Media", "``WM/IsCompilation``"
+   "RIFF INFO", "n/a"
 
 
 `Composer <https://musicbrainz.org/relationship/d59d99ea-23d4-4a80-b066-edca32ee158f>`_
@@ -248,6 +264,7 @@ Compilation (iTunes) [#f5]_
    "APEv2", "``Composer``"
    "iTunes MP4", "``©wrt``"
    "ASF/Windows Media", "``WM/Composer``"
+   "RIFF INFO", "``IMUS``"
 
 
 Composer Sort Order
@@ -262,6 +279,7 @@ Composer Sort Order
    "APEv2", "``COMPOSERSORT``"
    "iTunes MP4", "``soco``"
    "ASF/Windows Media", "``WM/ComposerSortOrder`` (Picard>=1.3)"
+   "RIFF INFO", "n/a"
 
 
 `Conductor <https://musicbrainz.org/relationship/234670ce-5f22-4fd0-921b-ef1662695c5d>`_
@@ -276,6 +294,7 @@ Composer Sort Order
    "APEv2", "``Conductor``"
    "iTunes MP4", "``----:com.apple.iTunes:CONDUCTOR``"
    "ASF/Windows Media", "``WM/Conductor``"
+   "RIFF INFO", "n/a"
 
 
 Copyright [#f4]_
@@ -290,6 +309,7 @@ Copyright [#f4]_
    "APEv2", "``Copyright``"
    "iTunes MP4", "``cprt``"
    "ASF/Windows Media", "``Copyright``"
+   "RIFF INFO", "``ICOP``"
 
 
 Disc Number
@@ -304,6 +324,7 @@ Disc Number
    "APEv2", "``Disc``"
    "iTunes MP4", "``disk``"
    "ASF/Windows Media", "``WM/PartOfSet``"
+   "RIFF INFO", "n/a"
 
 
 Disc Subtitle
@@ -318,6 +339,7 @@ Disc Subtitle
    "APEv2", "``DiscSubtitle``"
    "iTunes MP4", "``----:com.apple.iTunes:DISCSUBTITLE``"
    "ASF/Windows Media", "``WM/SetSubTitle``"
+   "RIFF INFO", "n/a"
 
 
 Encoded By [#f4]_
@@ -332,6 +354,7 @@ Encoded By [#f4]_
    "APEv2", "``EncodedBy``"
    "iTunes MP4", "``©too``"
    "ASF/Windows Media", "``WM/EncodedBy``"
+   "RIFF INFO", "``IENC``"
 
 
 Encoder Settings [#f4]_
@@ -346,6 +369,7 @@ Encoder Settings [#f4]_
    "APEv2", "``EncoderSettings``"
    "iTunes MP4", "n/a"
    "ASF/Windows Media", "``WM/EncodingSettings`` (Picard>=1.3.1)"
+   "RIFF INFO", "n/a"
 
 
 `Engineer <https://musicbrainz.org/relationship/5dcc52af-7064-4051-8d62-7d80f4c3c907>`_
@@ -360,6 +384,7 @@ Encoder Settings [#f4]_
    "APEv2", "``Engineer``"
    "iTunes MP4", "``----:com.apple.iTunes:ENGINEER``"
    "ASF/Windows Media", "``WM/Engineer``"
+   "RIFF INFO", "``IENG``"
 
 
 Gapless Playback [#f4]_
@@ -374,6 +399,7 @@ Gapless Playback [#f4]_
    "APEv2", "n/a"
    "iTunes MP4", "``pgap``"
    "ASF/Windows Media", "n/a"
+   "RIFF INFO", "n/a"
 
 
 `Genre <https://musicbrainz.org/doc/Genre>`_
@@ -388,6 +414,7 @@ Gapless Playback [#f4]_
    "APEv2", "``Genre``"
    "iTunes MP4", "``©gen``"
    "ASF/Windows Media", "``WM/Genre``"
+   "RIFF INFO", "``IGNR``"
 
 
 Grouping [#f3]_
@@ -402,6 +429,7 @@ Grouping [#f3]_
    "APEv2", "``Grouping``"
    "iTunes MP4", "``©grp``"
    "ASF/Windows Media", "``WM/ContentGroupDescription``"
+   "RIFF INFO", "n/a"
 
 
 Initial Key
@@ -416,6 +444,7 @@ Initial Key
    "APEv2", "``KEY``"
    "iTunes MP4", "``----:com.apple.iTunes:initialkey``"
    "ASF/Windows Media", "``WM/InitialKey``"
+   "RIFF INFO", "n/a"
 
 
 `ISRC <https://musicbrainz.org/doc/ISRC>`_
@@ -430,6 +459,7 @@ Initial Key
    "APEv2", "``ISRC``"
    "iTunes MP4", "``----:com.apple.iTunes:ISRC``"
    "ASF/Windows Media", "``WM/ISRC``"
+   "RIFF INFO", "n/a"
 
 
 Language
@@ -444,6 +474,7 @@ Language
    "APEv2", "``Language``"
    "iTunes MP4", "``----:com.apple.iTunes:LANGUAGE``"
    "ASF/Windows Media", "``WM/Language``"
+   "RIFF INFO", "``ILNG``"
 
 
 License [#f6]_ [#f7]_
@@ -458,6 +489,7 @@ License [#f6]_ [#f7]_
    "APEv2", "``LICENSE``"
    "iTunes MP4", "``----:com.apple.iTunes:LICENSE``"
    "ASF/Windows Media", "n/a"
+   "RIFF INFO", "n/a"
 
 
 `Lyricist <https://musicbrainz.org/relationship/3e48faba-ec01-47fd-8e89-30e81161661c>`_
@@ -472,6 +504,7 @@ License [#f6]_ [#f7]_
    "APEv2", "``Lyricist``"
    "iTunes MP4", "``----:com.apple.iTunes:LYRICIST``"
    "ASF/Windows Media", "``WM/Writer``"
+   "RIFF INFO", "n/a"
 
 
 Lyrics [#f4]_
@@ -486,6 +519,7 @@ Lyrics [#f4]_
    "APEv2", "``Lyrics``"
    "iTunes MP4", "``©lyr``"
    "ASF/Windows Media", "``WM/Lyrics``"
+   "RIFF INFO", "n/a"
 
 
 `Media <https://musicbrainz.org/doc/Release_Format>`_
@@ -500,6 +534,7 @@ Lyrics [#f4]_
    "APEv2", "``Media``"
    "iTunes MP4", "``----:com.apple.iTunes:MEDIA``"
    "ASF/Windows Media", "``WM/Media``"
+   "RIFF INFO", "``IMED``"
 
 
 `Mix-DJ <https://musicbrainz.org/relationship/28338ee6-d578-485a-bb53-61dbfd7c6545>`_
@@ -514,6 +549,7 @@ Lyrics [#f4]_
    "APEv2", "``DJMixer``"
    "iTunes MP4", "``----:com.apple.iTunes:DJMIXER``"
    "ASF/Windows Media", "``WM/DJMixer``"
+   "RIFF INFO", "n/a"
 
 
 `Mixer <https://musicbrainz.org/relationship/3e3102e1-1896-4f50-b5b2-dd9824e46efe>`_
@@ -528,6 +564,7 @@ Lyrics [#f4]_
    "APEv2", "``Mixer``"
    "iTunes MP4", "``----:com.apple.iTunes:MIXER``"
    "ASF/Windows Media", "``WM/Mixer``"
+   "RIFF INFO", "n/a"
 
 
 Mood [#f3]_
@@ -542,6 +579,7 @@ Mood [#f3]_
    "APEv2", "``Mood``"
    "iTunes MP4", "``----:com.apple.iTunes:MOOD``"
    "ASF/Windows Media", "``WM/Mood``"
+   "RIFF INFO", "n/a"
 
 
 Movement [#f4]_
@@ -556,6 +594,7 @@ Movement [#f4]_
    "APEv2", "``MOVEMENTNAME``"
    "iTunes MP4", "``©mvn``"
    "ASF/Windows Media", "n/a"
+   "RIFF INFO", "n/a"
 
 
 Movement Count [#f4]_
@@ -570,6 +609,7 @@ Movement Count [#f4]_
    "APEv2", "``MOVEMENTTOTAL``"
    "iTunes MP4", "``mvc``"
    "ASF/Windows Media", "n/a"
+   "RIFF INFO", "n/a"
 
 
 Movement Number [#f4]_
@@ -584,6 +624,7 @@ Movement Number [#f4]_
    "APEv2", "``MOVEMENT``"
    "iTunes MP4", "``mvi``"
    "ASF/Windows Media", "n/a"
+   "RIFF INFO", "n/a"
 
 
 `MusicBrainz Artist ID <https://musicbrainz.org/doc/MusicBrainz_Identifier>`_
@@ -598,6 +639,7 @@ Movement Number [#f4]_
    "APEv2", "``MUSICBRAINZ_ARTISTID``"
    "iTunes MP4", "``----:com.apple.iTunes:MusicBrainz Artist Id``"
    "ASF/Windows Media", "``MusicBrainz/Artist Id``"
+   "RIFF INFO", "n/a"
 
 
 `MusicBrainz Disc ID <https://musicbrainz.org/doc/Disc_ID>`_
@@ -612,6 +654,7 @@ Movement Number [#f4]_
    "APEv2", "``MUSICBRAINZ_DISCID``"
    "iTunes MP4", "``----:com.apple.iTunes:MusicBrainz Disc Id``"
    "ASF/Windows Media", "``MusicBrainz/Disc Id``"
+   "RIFF INFO", "n/a"
 
 
 `MusicBrainz Original Artist ID <https://musicbrainz.org/doc/MusicBrainz_Identifier>`_
@@ -626,6 +669,7 @@ Movement Number [#f4]_
    "APEv2", "n/a"
    "iTunes MP4", "``----:com.apple.iTunes:MusicBrainz Original Artist Id`` (Picard>=2.1)"
    "ASF/Windows Media", "``MusicBrainz/Original Artist Id`` (Picard>=2.1)"
+   "RIFF INFO", "n/a"
 
 
 `MusicBrainz Original Release ID <https://musicbrainz.org/doc/MusicBrainz_Identifier>`_
@@ -640,6 +684,7 @@ Movement Number [#f4]_
    "APEv2", "n/a"
    "iTunes MP4", "``----:com.apple.iTunes:MusicBrainz Original Album Id`` (Picard>=2.1)"
    "ASF/Windows Media", "``MusicBrainz/Original Album Id`` (Picard>=2.1)"
+   "RIFF INFO", "n/a"
 
 
 `MusicBrainz Recording ID <https://musicbrainz.org/doc/MusicBrainz_Identifier>`_
@@ -654,6 +699,7 @@ Movement Number [#f4]_
    "APEv2", "``MUSICBRAINZ_TRACKID``"
    "iTunes MP4", "``----:com.apple.iTunes:MusicBrainz Track Id``"
    "ASF/Windows Media", "``MusicBrainz/Track Id``"
+   "RIFF INFO", "n/a"
 
 
 `MusicBrainz Release Artist ID <https://musicbrainz.org/doc/MusicBrainz_Identifier>`_
@@ -668,6 +714,7 @@ Movement Number [#f4]_
    "APEv2", "``MUSICBRAINZ_ALBUMARTISTID``"
    "iTunes MP4", "``----:com.apple.iTunes:MusicBrainz Album Artist Id``"
    "ASF/Windows Media", "``MusicBrainz/Album Artist Id``"
+   "RIFF INFO", "n/a"
 
 
 MusicBrainz Release Group ID
@@ -682,6 +729,7 @@ MusicBrainz Release Group ID
    "APEv2", "``MUSICBRAINZ_RELEASEGROUPID``"
    "iTunes MP4", "``----:com.apple.iTunes:MusicBrainz Release Group Id``"
    "ASF/Windows Media", "``MusicBrainz/Release Group Id``"
+   "RIFF INFO", "n/a"
 
 
 `MusicBrainz Release ID <https://musicbrainz.org/doc/MusicBrainz_Identifier>`_
@@ -696,6 +744,7 @@ MusicBrainz Release Group ID
    "APEv2", "``MUSICBRAINZ_ALBUMID``"
    "iTunes MP4", "``----:com.apple.iTunes:MusicBrainz Album Id``"
    "ASF/Windows Media", "``MusicBrainz/Album Id``"
+   "RIFF INFO", "n/a"
 
 
 `MusicBrainz Track ID <https://musicbrainz.org/doc/MusicBrainz_Identifier>`_
@@ -710,6 +759,7 @@ MusicBrainz Release Group ID
    "APEv2", "``MUSICBRAINZ_RELEASETRACKID``"
    "iTunes MP4", "``----:com.apple.iTunes:MusicBrainz Release Track Id``"
    "ASF/Windows Media", "``MusicBrainz/Release Track Id``"
+   "RIFF INFO", "n/a"
 
 
 `MusicBrainz TRM ID <https://musicbrainz.org/doc/TRM>`_
@@ -724,6 +774,7 @@ MusicBrainz Release Group ID
    "APEv2", "``MUSICBRAINZ_TRMID``"
    "iTunes MP4", "``----:com.apple.iTunes:MusicBrainz TRM Id``"
    "ASF/Windows Media", "``MusicBrainz/TRM Id``"
+   "RIFF INFO", "n/a"
 
 
 MusicBrainz Work ID
@@ -738,6 +789,7 @@ MusicBrainz Work ID
    "APEv2", "``MUSICBRAINZ_WORKID``"
    "iTunes MP4", "``----:com.apple.iTunes:MusicBrainz Work Id``"
    "ASF/Windows Media", "``MusicBrainz/Work Id``"
+   "RIFF INFO", "n/a"
 
 
 MusicIP Fingerprint
@@ -752,6 +804,7 @@ MusicIP Fingerprint
    "APEv2", "n/a"
    "iTunes MP4", "``----:com.apple.iTunes:fingerprint``"
    "ASF/Windows Media", "n/a"
+   "RIFF INFO", "n/a"
 
 
 `MusicIP PUID <https://musicbrainz.org/doc/PUID>`_
@@ -766,6 +819,7 @@ MusicIP Fingerprint
    "APEv2", "``MUSICIP_PUID``"
    "iTunes MP4", "``----:com.apple.iTunes:MusicIP PUID``"
    "ASF/Windows Media", "``MusicIP/PUID``"
+   "RIFF INFO", "n/a"
 
 
 Original Album
@@ -780,6 +834,7 @@ Original Album
    "APEv2", "n/a"
    "iTunes MP4", "n/a"
    "ASF/Windows Media", "``WM/OriginalAlbumTitle`` (Picard>=2.1)"
+   "RIFF INFO", "n/a"
 
 
 Original Artist
@@ -794,6 +849,7 @@ Original Artist
    "APEv2", "``Original Artist`` (Picard>=2.1)"
    "iTunes MP4", "n/a"
    "ASF/Windows Media", "``WM/OriginalArtist`` (Picard>=2.1)"
+   "RIFF INFO", "n/a"
 
 
 Original Filename
@@ -808,6 +864,7 @@ Original Filename
    "APEv2", "``ORIGINALFILENAME``"
    "iTunes MP4", "n/a"
    "ASF/Windows Media", "``WM/OriginalFilename``"
+   "RIFF INFO", "n/a"
 
 
 Original Release Date [#f1]_
@@ -822,6 +879,7 @@ Original Release Date [#f1]_
    "APEv2", "n/a"
    "iTunes MP4", "n/a"
    "ASF/Windows Media", "``WM/OriginalReleaseTime`` (Picard>=1.3.1) ``WM/OriginalReleaseYear`` (Picard<=1.3.0)"
+   "RIFF INFO", "n/a"
 
 
 Original Release Year [#f1]_
@@ -836,6 +894,7 @@ Original Release Year [#f1]_
    "APEv2", "``ORIGINALYEAR``"
    "iTunes MP4", "n/a"
    "ASF/Windows Media", "``WM/OriginalReleaseYear`` (Picard>=1.3.1)"
+   "RIFF INFO", "n/a"
 
 
 Performer
@@ -850,6 +909,7 @@ Performer
    "APEv2", "``Performer={artist} (instrument)``"
    "iTunes MP4", "n/a"
    "ASF/Windows Media", "n/a"
+   "RIFF INFO", "n/a"
 
 .. seealso::
 
@@ -875,6 +935,7 @@ Podcast [#f4]_
    "APEv2", "n/a"
    "iTunes MP4", "``pcst``"
    "ASF/Windows Media", "n/a"
+   "RIFF INFO", "n/a"
 
 
 Podcast URL [#f4]_
@@ -889,6 +950,7 @@ Podcast URL [#f4]_
    "APEv2", "n/a"
    "iTunes MP4", "``purl``"
    "ASF/Windows Media", "n/a"
+   "RIFF INFO", "n/a"
 
 
 `Producer <https://musicbrainz.org/relationship/5c0ceac3-feb4-41f0-868d-dc06f6e27fc0>`_
@@ -903,6 +965,7 @@ Podcast URL [#f4]_
    "APEv2", "``Producer``"
    "iTunes MP4", "``----:com.apple.iTunes:PRODUCER``"
    "ASF/Windows Media", "``WM/Producer``"
+   "RIFF INFO", "``IPRO``"
 
 
 `Rating <https://musicbrainz.org/doc/Rating_System>`_
@@ -917,6 +980,7 @@ Podcast URL [#f4]_
    "APEv2", "n/a"
    "iTunes MP4", "n/a"
    "ASF/Windows Media", "``WM/SharedUserRating``"
+   "RIFF INFO", "n/a"
 
 
 `Record Label <https://musicbrainz.org/doc/Label_Name>`_
@@ -931,6 +995,7 @@ Podcast URL [#f4]_
    "APEv2", "``Label``"
    "iTunes MP4", "``----:com.apple.iTunes:LABEL``"
    "ASF/Windows Media", "``WM/Publisher``"
+   "RIFF INFO", "n/a"
 
 
 `Release Country <https://musicbrainz.org/doc/Release_Country>`_
@@ -945,6 +1010,7 @@ Podcast URL [#f4]_
    "APEv2", "``RELEASECOUNTRY``"
    "iTunes MP4", "``----:com.apple.iTunes:MusicBrainz Album Release Country``"
    "ASF/Windows Media", "``MusicBrainz/Album Release Country``"
+   "RIFF INFO", "``ICNT``"
 
 
 `Release Date <https://musicbrainz.org/doc/Release_Date>`_
@@ -959,6 +1025,7 @@ Podcast URL [#f4]_
    "APEv2", "``Year``"
    "iTunes MP4", "``©day``"
    "ASF/Windows Media", "``WM/Year``"
+   "RIFF INFO", "``ICRD``"
 
 
 `Release Status <https://musicbrainz.org/doc/Release_Status>`_
@@ -973,6 +1040,7 @@ Podcast URL [#f4]_
    "APEv2", "``MUSICBRAINZ_ALBUMSTATUS``"
    "iTunes MP4", "``----:com.apple.iTunes:MusicBrainz Album Status``"
    "ASF/Windows Media", "``MusicBrainz/Album Status``"
+   "RIFF INFO", "n/a"
 
 
 `Release Type <https://musicbrainz.org/doc/Release_Type>`_
@@ -987,6 +1055,7 @@ Podcast URL [#f4]_
    "APEv2", "``MUSICBRAINZ_ALBUMTYPE``"
    "iTunes MP4", "``----:com.apple.iTunes:MusicBrainz Album Type``"
    "ASF/Windows Media", "``MusicBrainz/Album Type``"
+   "RIFF INFO", "n/a"
 
 
 `Remixer <https://musicbrainz.org/relationship/7950be4d-13a3-48e7-906b-5af562e39544>`_
@@ -1001,6 +1070,7 @@ Podcast URL [#f4]_
    "APEv2", "``MixArtist``"
    "iTunes MP4", "``----:com.apple.iTunes:REMIXER``"
    "ASF/Windows Media", "``WM/ModifiedBy``"
+   "RIFF INFO", "n/a"
 
 
 ReplayGain Album Gain
@@ -1015,6 +1085,7 @@ ReplayGain Album Gain
    "APEv2", "``REPLAYGAIN_ALBUM_GAIN``"
    "iTunes MP4", "``----:com.apple.iTunes:REPLAYGAIN_ALBUM_GAIN``"
    "ASF/Windows Media", "``REPLAYGAIN_ALBUM_GAIN``"
+   "RIFF INFO", "n/a"
 
 
 ReplayGain Album Peak
@@ -1029,6 +1100,7 @@ ReplayGain Album Peak
    "APEv2", "``REPLAYGAIN_ALBUM_PEAK``"
    "iTunes MP4", "``----:com.apple.iTunes:REPLAYGAIN_ALBUM_PEAK``"
    "ASF/Windows Media", "``REPLAYGAIN_ALBUM_PEAK``"
+   "RIFF INFO", "n/a"
 
 
 ReplayGain Album Range
@@ -1043,6 +1115,7 @@ ReplayGain Album Range
    "APEv2", "``REPLAYGAIN_ALBUM_RANGE``"
    "iTunes MP4", "``----:com.apple.iTunes:REPLAYGAIN_ALBUM_RANGE``"
    "ASF/Windows Media", "``REPLAYGAIN_ALBUM_RANGE``"
+   "RIFF INFO", "n/a"
 
 
 ReplayGain Reference Loudness
@@ -1057,6 +1130,7 @@ ReplayGain Reference Loudness
    "APEv2", "``REPLAYGAIN_REFERENCE_LOUDNESS``"
    "iTunes MP4", "``----:com.apple.iTunes:REPLAYGAIN_REFERENCE_LOUDNESS``"
    "ASF/Windows Media", "``REPLAYGAIN_REFERENCE_LOUDNESS``"
+   "RIFF INFO", "n/a"
 
 
 ReplayGain Track Gain
@@ -1071,6 +1145,7 @@ ReplayGain Track Gain
    "APEv2", "``REPLAYGAIN_TRACK_GAIN``"
    "iTunes MP4", "``----:com.apple.iTunes:REPLAYGAIN_TRACK_GAIN``"
    "ASF/Windows Media", "``REPLAYGAIN_TRACK_GAIN``"
+   "RIFF INFO", "n/a"
 
 
 ReplayGain Track Peak
@@ -1085,6 +1160,7 @@ ReplayGain Track Peak
    "APEv2", "``REPLAYGAIN_TRACK_PEAK``"
    "iTunes MP4", "``----:com.apple.iTunes:REPLAYGAIN_TRACK_PEAK``"
    "ASF/Windows Media", "``REPLAYGAIN_TRACK_PEAK``"
+   "RIFF INFO", "n/a"
 
 
 ReplayGain Track Range
@@ -1099,6 +1175,7 @@ ReplayGain Track Range
    "APEv2", "``REPLAYGAIN_TRACK_RANGE``"
    "iTunes MP4", "``----:com.apple.iTunes:REPLAYGAIN_TRACK_RANGE``"
    "ASF/Windows Media", "``REPLAYGAIN_TRACK_RANGE``"
+   "RIFF INFO", "n/a"
 
 
 Script
@@ -1113,6 +1190,7 @@ Script
    "APEv2", "``Script``"
    "iTunes MP4", "``----:com.apple.iTunes:SCRIPT``"
    "ASF/Windows Media", "``WM/Script``"
+   "RIFF INFO", "n/a"
 
 
 Show Name [#f4]_
@@ -1127,6 +1205,7 @@ Show Name [#f4]_
    "APEv2", "n/a"
    "iTunes MP4", "``tvsh``"
    "ASF/Windows Media", "n/a"
+   "RIFF INFO", "n/a"
 
 
 Show Name Sort Order [#f4]_
@@ -1141,6 +1220,7 @@ Show Name Sort Order [#f4]_
    "APEv2", "n/a"
    "iTunes MP4", "``sosn``"
    "ASF/Windows Media", "n/a"
+   "RIFF INFO", "n/a"
 
 
 Show Work & Movement [#f4]_
@@ -1155,6 +1235,7 @@ Show Work & Movement [#f4]_
    "APEv2", "``SHOWMOVEMENT``"
    "iTunes MP4", "``shwm``"
    "ASF/Windows Media", "n/a"
+   "RIFF INFO", "n/a"
 
 
 Subtitle [#f4]_
@@ -1169,6 +1250,7 @@ Subtitle [#f4]_
    "APEv2", "``Subtitle``"
    "iTunes MP4", "``----:com.apple.iTunes:SUBTITLE``"
    "ASF/Windows Media", "``WM/SubTitle``"
+   "RIFF INFO", "n/a"
 
 
 Total Discs
@@ -1183,6 +1265,7 @@ Total Discs
    "APEv2", "``Disc``"
    "iTunes MP4", "``disk``"
    "ASF/Windows Media", "``WM/PartOfSet`` (Picard>=1.3.1)"
+   "RIFF INFO", "n/a"
 
 
 Total Tracks
@@ -1197,6 +1280,7 @@ Total Tracks
    "APEv2", "``Track``"
    "iTunes MP4", "``trkn``"
    "ASF/Windows Media", "n/a"
+   "RIFF INFO", "n/a"
 
 
 Track Number
@@ -1211,6 +1295,7 @@ Track Number
    "APEv2", "``Track``"
    "iTunes MP4", "``trkn``"
    "ASF/Windows Media", "``WM/TrackNumber``"
+   "RIFF INFO", "``ITRK``"
 
 
 `Track Title <https://musicbrainz.org/doc/Track_Title>`_
@@ -1225,6 +1310,7 @@ Track Number
    "APEv2", "``Title``"
    "iTunes MP4", "``©nam``"
    "ASF/Windows Media", "``Title``"
+   "RIFF INFO", "``INAM``"
 
 
 Track Title Sort Order [#f4]_
@@ -1239,6 +1325,7 @@ Track Title Sort Order [#f4]_
    "APEv2", "``TITLESORT``"
    "iTunes MP4", "``sonm``"
    "ASF/Windows Media", "``WM/TitleSortOrder``"
+   "RIFF INFO", "n/a"
 
 
 Website (official artist website)
@@ -1253,6 +1340,7 @@ Website (official artist website)
    "APEv2", "``Weblink``"
    "iTunes MP4", "n/a"
    "ASF/Windows Media", "``WM/AuthorURL`` (Picard>=1.3.1)"
+   "RIFF INFO", "n/a"
 
 
 Work Title
@@ -1267,6 +1355,7 @@ Work Title
    "APEv2", "``WORK``"
    "iTunes MP4", "``©wrk`` (Picard>=2.1)"
    "ASF/Windows Media", "``WM/Work``"
+   "RIFF INFO", "n/a"
 
 
 `Writer <https://musicbrainz.org/relationship/a255bca1-b157-4518-9108-7b147dc3fc68>`_ [#f2]_
@@ -1281,6 +1370,7 @@ Work Title
    "APEv2", "``Writer``"
    "iTunes MP4", "n/a"
    "ASF/Windows Media", "n/a"
+   "RIFF INFO", "``IWRI``"
 
 
 .. only:: html


### PR DESCRIPTION
<!--
    Thank-you for submitting a pull request. Your effort and input is appreciated.

    Please use this template to help us review your change. Not everything is
    required for every change, so please feel free to omit any sections that
    are not relevant to your change.

    Also, please ensure that you've reviewed the guidelines in CONTRIBUTING.md.
-->

### Summary

This is a…

- [ ] Correction
- [x] Addition
- [ ] Restructuring
- [ ] Minor / simple change (like a typo)
- [ ] Other

### Description of the Change

Add documentation of RIFF INFO mapping to tag mapping table. Compare https://github.com/metabrainz/picard/blob/master/picard/formats/wav.py#L46