### PR TITLE
2.5 update file variables docs

### DIFF
--- a/source/variables/tags_basic.rst
+++ b/source/variables/tags_basic.rst
@@ -51,10 +51,6 @@ several other more minor settings) by wrapping them between percent '%' symbols 
       Some of these tags are only supported for certain file types or tag formats.  Please see the :doc:`Picard Tag Mapping
       <../technical/tag_mapping_pdf>` section for details.
 
-.. note::
-
-   Tags that rely on information from the files (e.g.: bpm) are only available for use in the file naming script.
-
 **acoustid_fingerprint**
 
     AcoustID Fingerprint for the track.

--- a/source/variables/variables.rst
+++ b/source/variables/variables.rst
@@ -38,6 +38,7 @@ release. A description of how to gain access to these beta versions for testing 
       :doc:`tags_basic` /
       :doc:`tags_advanced` /
       :doc:`variables_basic` /
+      :doc:`variables_file` /
       :doc:`variables_advanced` /
       :doc:`variables_classical` /
       :doc:`variables_plugins` /
@@ -49,6 +50,7 @@ release. A description of how to gain access to these beta versions for testing 
    tags_basic
    tags_advanced
    variables_basic
+   variables_file
    variables_advanced
    variables_classical
    variables_plugins

--- a/source/variables/variables_basic.rst
+++ b/source/variables/variables_basic.rst
@@ -21,7 +21,8 @@ These variables are populated from MusicBrainz data for most releases, without a
 
 .. note::
 
-   Variables that rely on information from the files (e.g.: _bitrate) are only available for use in the file naming script.
+   Variables that rely on information from the files (e.g.: _bitrate) are only available for use on
+   tracks with attached files or in the file naming script.
 
 **_absolutetracknumber**
 
@@ -42,31 +43,31 @@ These variables are populated from MusicBrainz data for most releases, without a
 
 **_bitrate**
 
-    Approximate bitrate in kbps.  Only available to the file naming script.
+    Approximate bitrate in kbps.
 
 **_bits_per_sample**
 
-    Bits of data per sample.  Only available to the file naming script.
+    Bits of data per sample.
 
 **_channels**
 
-    Number of audio channels in the file.  Only available to the file naming script.
+    Number of audio channels in the file.
 
 **_dirname**
 
-    The name of the directory containing the file at the point of being loaded into Picard.  Only available to the file naming script. (*since Picard 1.1*)
+    The name of the directory containing the file at the point of being loaded into Picard. (*since Picard 1.1*)
 
 **_extension**
 
-    The file's extension.  Only available to the file naming script. (*since Picard 0.9*)
+    The file's extension. (*since Picard 0.9*)
 
 **_filename**
 
-    The name of the file without extension.  Only available to the file naming script. (*since Picard 1.1*)
+    The name of the file without extension. (*since Picard 1.1*)
 
 **_format**
 
-    Media format of the file (e.g.: MPEG-1 Audio).  Only available to the file naming script.
+    Media format of the file (e.g.: MPEG-1 Audio).
 
 **_length**
 
@@ -104,7 +105,7 @@ These variables are populated from MusicBrainz data for most releases, without a
 
 **_sample_rate**
 
-    Number of digitizing samples per second (Hz).  Only available to the file naming script.
+    Number of digitizing samples per second (Hz).
 
 .. _ref_secondaryreleasetype:
 

--- a/source/variables/variables_basic.rst
+++ b/source/variables/variables_basic.rst
@@ -19,11 +19,6 @@ These variables are populated from MusicBrainz data for most releases, without a
 
    Variables will not be created if there was no value retrieved for the variable from the MusicBrainz database.
 
-.. note::
-
-   Variables that rely on information from the files (e.g.: _bitrate) are only available for use on
-   tracks with attached files or in the file naming script.
-
 **_absolutetracknumber**
 
     The absolute number of this track disregarding the disc number (i.e.: ``%_absolutetracknumber%`` of ``%_totalalbumtracks%``).
@@ -40,38 +35,6 @@ These variables are populated from MusicBrainz data for most releases, without a
 **_artists_sort**
 
     The Artist's Sort Name(s) (multi-value). (*since Picard 1.3*)
-
-**_bitrate**
-
-    Approximate bitrate in kbps.
-
-**_bits_per_sample**
-
-    Bits of data per sample.
-
-**_channels**
-
-    Number of audio channels in the file.
-
-**_dirname**
-
-    The name of the directory containing the file at the point of being loaded into Picard. (*since Picard 1.1*)
-
-**_extension**
-
-    The file's extension. (*since Picard 0.9*)
-
-**_filename**
-
-    The name of the file without extension. (*since Picard 1.1*)
-
-**_format**
-
-    Media format of the file (e.g.: MPEG-1 Audio).
-
-**_length**
-
-    The length of the track in format mins:secs.
 
 **_multiartist**
 
@@ -102,10 +65,6 @@ These variables are populated from MusicBrainz data for most releases, without a
 **_releaselanguage**
 
     Release Language as per `ISO 639-3 <https://en.wikipedia.org/wiki/ISO_639-3>`_. (*since Picard 0.10*)
-
-**_sample_rate**
-
-    Number of digitizing samples per second (Hz).
 
 .. _ref_secondaryreleasetype:
 

--- a/source/variables/variables_file.rst
+++ b/source/variables/variables_file.rst
@@ -1,0 +1,57 @@
+.. MusicBrainz Picard Documentation Project
+.. Prepared in 2020 by Bob Swift (bswift@rsds.ca)
+.. This MusicBrainz Picard User Guide is licensed under CC0 1.0
+.. A copy of the license is available at https://creativecommons.org/publicdomain/zero/1.0
+
+File Variables
+===============
+
+.. index::
+   single: variables; file
+
+These variables are populated from MusicBrainz data for most releases, without any special Picard settings.
+
+.. note::
+
+   Variables that rely on information from the files (e.g.: _bitrate) are only available for use on
+   tracks with attached files, when running scripts manually on files or in the file naming script.
+
+.. warning::
+
+   Prior to version 2.5 Picard did not support using file variables in tagging scripts.
+
+**_bitrate**
+
+    Approximate bitrate in kbps.
+
+**_bits_per_sample**
+
+    Bits of data per sample.
+
+**_channels**
+
+    Number of audio channels in the file.
+
+**_dirname**
+
+    The name of the directory containing the file at the point of being loaded into Picard (*since Picard 1.1*).
+
+**_extension**
+
+    The file's extension (*since Picard 0.9*).
+
+**_filename**
+
+    The name of the file without extension (*since Picard 1.1*).
+
+**_format**
+
+    Media format of the file (e.g.: MPEG-1 Audio).
+
+**_length**
+
+    The length of the track in format mins:secs.
+
+**_sample_rate**
+
+    Number of digitizing samples per second (Hz).


### PR DESCRIPTION
<!--
    Thank-you for submitting a pull request. Your effort and input is appreciated.

    Please use this template to help us review your change. Not everything is
    required for every change, so please feel free to omit any sections that
    are not relevant to your change.

    Also, please ensure that you've reviewed the guidelines in CONTRIBUTING.md.
-->

### Summary

This is a…

- [ ] Correction
- [x] Addition
- [x] Restructuring
- [ ] Minor / simple change (like a typo)
- [ ] Other

### Reason for the Change

Picard 2.5 will allow using file specific variables in tagging scripts.

### Description of the Change

Moved the special file variables to a separate page for clarity. Removed the notes that those are only available in naming script, but add a warning that this is the case in older versions of Picard