### PR TITLE
Document Picard 2.5 behavior of dropping multiple files onto a track

### DIFF
--- a/source/usage/match.rst
+++ b/source/usage/match.rst
@@ -22,6 +22,16 @@ matching for you.  If the matching wasn't done automatically, drag the appropria
 .. image:: ../images/lookup_4.png
    :width: 100%
 
+.. note::
+
+   If you drag and drop multiple files onto a specific track the first selected file will be matched to the track on
+   which you dropped the files.  The rest of the selected files will be matched to the following tracks in order.
+   This allows you to quickly match multiple files to a sequence of tracks.  If you want to match all files to a single
+   track instead you can hold the :kbd:`Alt` key while dropping the files.
+
+   If you drop multiple files onto an album Picard will try to match the files to the tracks based on the metadata.
+
+
 Depending on your previous metadata, Picard will try to guess the matching tracks. The order is green > yellow > orange > red,
 where green is the best match. If you are seeing a lot of red and orange, it could mean that Picard has guessed incorrectly, or that
 your files didn't have a lot of previous metadata to work with.  If this is the case, it's recommended to select a track and


### PR DESCRIPTION
<!--
    Thank-you for submitting a pull request. Your effort and input is appreciated.

    Please use this template to help us review your change. Not everything is
    required for every change, so please feel free to omit any sections that
    are not relevant to your change.

    Also, please ensure that you've reviewed the guidelines in CONTRIBUTING.md.
-->

### Summary

This is a…

- [ ] Correction
- [x] Addition
- [ ] Restructuring
- [ ] Minor / simple change (like a typo)
- [ ] Other

### Reason for the Change

Picard 2.5 allows to drag and drop multiple files on tracks and have them assigned to multiple tracks.

### Description of the Change

Add a note to the "Matching Files to Tracks" section describing the drag and drop behavior and how to disable this temporarily.