### PR TITLE
Add an FAQ entry about app being shown as damaged on macOS

### DIFF
--- a/source/faq/faq.rst
+++ b/source/faq/faq.rst
@@ -15,6 +15,7 @@ Some of the most often asked questions have been addressed in the following sect
    * :doc:`faq_usage_tagger_icon`
    * :doc:`faq_usage_load_album_errors`
    * :doc:`faq_usage_macos_drives`
+   * :doc:`faq_usage_macos_startup_error`
    * :doc:`faq_config_where_saved`
    * :doc:`faq_config_itunes`
    * :doc:`faq_config_tags_truncated`
@@ -33,6 +34,7 @@ Some of the most often asked questions have been addressed in the following sect
    faq_usage_tagger_icon
    faq_usage_load_album_errors
    faq_usage_macos_drives
+   faq_usage_macos_startup_error
    faq_config_where_saved
    faq_config_itunes
    faq_config_tags_truncated

--- a/source/faq/faq_usage_macos_startup_error.rst
+++ b/source/faq/faq_usage_macos_startup_error.rst
@@ -1,0 +1,25 @@
+.. MusicBrainz Picard Documentation Project
+.. Prepared in 2020 by Bob Swift (bswift@rsds.ca)
+.. This MusicBrainz Picard User Guide is licensed under CC0 1.0
+.. A copy of the license is available at https://creativecommons.org/publicdomain/zero/1.0
+
+
+macOS shows the app is damaged. How can I run Picard?
+=====================================================
+
+.. index::
+   single: macos
+
+On macOS 10.12 and 10.13 there have been reports that sometimes the MusicBrainz Picard app
+cannot be started and macOS shows an error message:
+
+    "MusicBrainz Picard.app" is damaged and can't be opened. You should move it to the Trash.
+
+This mostly seems to happen after moving the file to the Applications folder and seems to be
+caused by Gatekeeper mistakenly marking the app as damaged.  To solve the issue open a terminal
+and run::
+
+    xattr -c "/Applications/MusicBrainz Picard.app"
+
+This will clear the app being marked as damaged.  If you have placed the app in a different
+location then :file:`/Applications` adjust the path in the command above accordingly.


### PR DESCRIPTION


<!--
    Thank-you for submitting a pull request. Your effort and input is appreciated.

    Please use this template to help us review your change. Not everything is
    required for every change, so please feel free to omit any sections that
    are not relevant to your change.

    Also, please ensure that you've reviewed the guidelines in CONTRIBUTING.md.
-->

### Summary

This is a…

- [ ] Correction
- [x] Addition
- [ ] Restructuring
- [ ] Minor / simple change (like a typo)
- [ ] Other

### Reason for the Change

There have been frequent reports about the macOS app getting an error message about the app being damaged. To all we can tell this is not caused by the app, but a problem with macOS Gatekeeper. As this is outside our control have an FAQ entry to help users get around this.

See https://tickets.metabrainz.org/browse/PICARD-1763 and related discussions
