### PR TITLE
Document usage of custom MP4 tags, update docs on custom tags

### DIFF
--- a/source/variables/variables_other_information.rst
+++ b/source/variables/variables_other_information.rst
@@ -17,8 +17,18 @@ Other Information
 
    For technical details on how tags are written into files, see the :doc:`Picard Tag Mapping <../technical/tag_mapping_pdf>` section.
 
-If you set new variables, these will be saved as new tags in ID3, APEv2 and VORBIS based files. For ID3 based files these will be
-saved to, and reloaded from, ID3 user defined text information (TXXX) frames. They will not be saved in ASF or MP4 based files.
+If you set variables that are not known to Picard, these will be saved as new tags in ID3, MP4, APEv2 and Vorbis based files.
+They will not be saved in ASF based files.
+
+- For ID3 based files these tags will be saved to, and reloaded from, ID3 user defined text information (TXXX) frames.
+- For MP4 files these tags will be saved with a prefix of ``----:com.apple.iTunes:``.  This is widely understood by
+  other tools to be used for custom tags.
+- For Vorbis and APEv2 files these tags will be saved as given.
 
 For ID3 based tags (i.e.: MP3 files), you can also set ID3 tags directly from your scripts by setting a special variable starting with
-"_id3:". Currently these tags are not loaded into variables when you reload the file into Picard (*since Picard 0.9*).
+``_id3:``, e.g. ``%_id3:TXXX:mytag``. Currently these tags are not loaded into variables when you reload the file into Picard (*since Picard 0.9*).
+
+.. note::
+
+   Saving custom tags to MP4 files is supported since Picard 2.3.  Earlier versions will neither save nor load
+   custom tags in MP4 files.


### PR DESCRIPTION

<!--
    Thank-you for submitting a pull request. Your effort and input is appreciated.

    Please use this template to help us review your change. Not everything is
    required for every change, so please feel free to omit any sections that
    are not relevant to your change.

    Also, please ensure that you've reviewed the guidelines in CONTRIBUTING.md.
-->

### Summary

This is a…

- [ ] Correction
- [x] Addition
- [ ] Restructuring
- [ ] Minor / simple change (like a typo)
- [ ] Other

### Reason for the Change

In https://picard-docs.musicbrainz.org/en/variables/variables_other_information.html the handling of custom tags is explained. This currently misses MP4, for which Picard also allows writing custom tags since version 2.3.

### Description of the Change

Rework the documentation how Picard handles unknown tags.