### PR TITLE
Add note to regular expression functions about escaping '\', '(' and ')'

### DIFF
--- a/_locale/fr/LC_MESSAGES/extending/scripting.po
+++ b/_locale/fr/LC_MESSAGES/extending/scripting.po
@@ -8,8 +8,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: MusicBrainz Picard v2.3.2\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-11-18 17:04-0700\n"
-"PO-Revision-Date: 2020-11-19 16:25-0700\n"
+"POT-Creation-Date: 2020-11-29 15:51-0700\n"
+"PO-Revision-Date: 2020-11-29 15:55-0700\n"
 "Last-Translator: Bob Swift <bswift@rsds.ca>\n"
 "Language: fr\n"
 "Language-Team: \n"
@@ -86,19 +86,30 @@ msgstr ""
 "commencent par un signe dollar et se terminent par une liste d'arguments "
 "entre parenthèses (par exemple: ``$lower(...)``)."
 
-#: ../../extending/scripting.rst:31
+#: ../../extending/scripting.rst:33
 msgid ""
-"To use parentheses or commas as-is inside a function call, you must "
-"escape them with a backslash."
+"When entering input strings into Picard scripts you have to escape a "
+"backslash \"\\\\\", dollar sign \"$\", comma \",\" and the left and right "
+"parentheses \"(\" and \")\" in order to force Picard to not interpret "
+"them as part of the script command.  This is done by inserting a "
+"backslash before the character to be escaped.  For example, to set a tag "
+"value to ``($1,000,000)`` it would have to be entered as ``$set(test_tag,"
+"\\(\\$1\\,000\\,000\\))``."
 msgstr ""
-"Pour utiliser des parenthèses ou des virgules telles quelles dans un "
-"appel de fonction, vous devez les échapper avec une barre oblique inverse."
+"Lorsque vous entrez des chaînes d'entrée dans des scripts Picard, vous "
+"devez échapper une barre oblique inverse \"\\\\\", un signe dollar \"$\", "
+"une virgule \",\" et les parenthèses gauche et droite \"(\" et \")\" afin "
+"de forcer Picard à ne pas les interpréter dans le cadre de la commande de "
+"script. Cela se fait en insérant une barre oblique inverse avant le "
+"caractère à échapper. Par exemple, pour définir une valeur de balise sur "
+"``($1,000,000)``, il faudrait la saisir sous la forme ``$set(test_tag,"
+"\\(\\$1\\,000\\,000\\))``."
 
-#: ../../extending/scripting.rst:35
+#: ../../extending/scripting.rst:40
 msgid "Metadata Variables"
 msgstr "Variables de métadonnées"
 
-#: ../../extending/scripting.rst:37
+#: ../../extending/scripting.rst:42
 msgid ""
 "See :doc:`../variables/variables` for the list of the variables provided "
 "by Picard."
@@ -106,7 +117,7 @@ msgstr ""
 "Voir :doc:`../variables/variables` pour la liste des variables fournies "
 "par Picard."
 
-#: ../../extending/scripting.rst:39
+#: ../../extending/scripting.rst:44
 msgid ""
 "Picard's variables can be either simple variables containing a single "
 "text string, or multi-value variables containing multiple text strings. "
@@ -121,7 +132,7 @@ msgstr ""
 "texte en joignant les valeurs par un point-virgule ';', sauf lorsqu'elles "
 "sont utilisées avec des fonctions spéciales à valeurs multiples."
 
-#: ../../extending/scripting.rst:57
+#: ../../extending/scripting.rst:62
 msgid ""
 "The full list of available scripting functions is covered in the "
 "following chapter."
@@ -129,11 +140,11 @@ msgstr ""
 "La liste complète des fonctions de script disponibles est couverte dans "
 "le chapitre suivant."
 
-#: ../../extending/scripting.rst:47
+#: ../../extending/scripting.rst:52
 msgid "Scripting Functions"
 msgstr "Fonctions de script"
 
-#: ../../extending/scripting.rst:49
+#: ../../extending/scripting.rst:54
 msgid ""
 "The full list of available scripting functions is available, either :doc:"
 "`sorted alphabetically <../functions/list_by_name>` or :doc:`grouped by "
@@ -148,3 +159,11 @@ msgstr ""
 
 #~ msgid "Syntax"
 #~ msgstr "Syntaxe"
+
+#~ msgid ""
+#~ "To use parentheses or commas as-is inside a function call, you must "
+#~ "escape them with a backslash."
+#~ msgstr ""
+#~ "Pour utiliser des parenthèses ou des virgules telles quelles dans un "
+#~ "appel de fonction, vous devez les échapper avec une barre oblique "
+#~ "inverse."

--- a/_locale/fr/LC_MESSAGES/functions/func_rreplace.po
+++ b/_locale/fr/LC_MESSAGES/functions/func_rreplace.po
@@ -8,35 +8,35 @@ msgid ""
 msgstr ""
 "Project-Id-Version: MusicBrainz Picard v2.3.2\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-09-16 18:38-0600\n"
-"PO-Revision-Date: 2020-10-08 14:01-0600\n"
+"POT-Creation-Date: 2020-11-29 15:10-0700\n"
+"PO-Revision-Date: 2020-11-29 15:16-0700\n"
+"Last-Translator: Bob Swift <bswift@rsds.ca>\n"
+"Language: fr\n"
+"Language-Team: \n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.8.0\n"
-"Plural-Forms: nplurals=2; plural=(n > 1);\n"
-"Last-Translator: Bob Swift <bswift@rsds.ca>\n"
-"Language-Team: \n"
-"Language: fr\n"
-"X-Generator: Poedit 2.4.1\n"
+"X-Generator: Poedit 2.4.2\n"
 
-#: ../../functions/func_rreplace.rst:7
+#: ../../functions/func_rreplace.rst:4
 msgid "$rreplace"
 msgstr "$rreplace"
 
-#: ../../functions/func_rreplace.rst:9
+#: ../../functions/func_rreplace.rst:6
 msgid "Usage: **$rreplace(text,pattern,replace)**"
 msgstr "Utilisation: **$rreplace(texte,motif,remplacement)**"
 
-#: ../../functions/func_rreplace.rst:10
+#: ../../functions/func_rreplace.rst:7
 msgid "Category: text"
 msgstr "Catégorie: texte"
 
-#: ../../functions/func_rreplace.rst:12
+#: ../../functions/func_rreplace.rst:9
 msgid "**Description:**"
 msgstr "**La description:**"
 
-#: ../../functions/func_rreplace.rst:14
+#: ../../functions/func_rreplace.rst:11
 msgid ""
 "Regular expression replace. This function will replace the matching "
 "group specified by ``pattern`` with ``replace`` in ``text``.  For more "
@@ -49,10 +49,29 @@ msgstr ""
 "veuillez consulter `l'article sur Wikipedia <https://wikipedia.org/wiki/"
 "Regular_expression>`_."
 
-#: ../../functions/func_rreplace.rst:20
+#: ../../functions/func_rreplace.rst:17
+msgid ""
+"When entering regular expressions into Picard scripts you have to escape "
+"a backslash \"\\\\\", dollar sign \"$\", comma \",\" and the left and "
+"right parentheses \"(\" and \")\" in order to force Picard to not "
+"interpret them as part of the script command.  This is done by inserting "
+"a backslash before the character to be escaped.  For example, the "
+"regular expression ``^\\s*([0-9,\\.]*)$`` would have to be entered as ``^"
+"\\\\s*\\([0-9\\,\\\\.]*\\)\\$``."
+msgstr ""
+"Lors de la saisie d'expressions régulières dans des scripts Picard, vous "
+"devez échapper une barre oblique inverse \"\\\\\", un signe dollar \"$"
+"\", une virgule \",\" et les parenthèses gauche et droite \"(\" et \")\" "
+"pour forcer Picard à ne pas les interpréter dans le cadre de la commande "
+"de script. Cela se fait en insérant une barre oblique inverse avant le "
+"caractère à échapper. Par exemple, l'expression régulière ``^\\s*([0-9,"
+"\\.]*)$`` devrait être saisie sous la forme ``^\\\\s*\\([0-9\\,\\\\.]*"
+"\\)\\$``."
+
+#: ../../functions/func_rreplace.rst:23
 msgid "**Example:**"
 msgstr "**Exemple:**"
 
-#: ../../functions/func_rreplace.rst:22
+#: ../../functions/func_rreplace.rst:25
 msgid "The following statements will return the values indicated::"
 msgstr "Les instructions suivantes renverront les valeurs indiquées::"

--- a/_locale/fr/LC_MESSAGES/functions/func_rsearch.po
+++ b/_locale/fr/LC_MESSAGES/functions/func_rsearch.po
@@ -8,35 +8,35 @@ msgid ""
 msgstr ""
 "Project-Id-Version: MusicBrainz Picard v2.3.2\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-09-16 18:38-0600\n"
-"PO-Revision-Date: 2020-10-08 14:04-0600\n"
+"POT-Creation-Date: 2020-11-29 15:10-0700\n"
+"PO-Revision-Date: 2020-11-29 15:16-0700\n"
+"Last-Translator: Bob Swift <bswift@rsds.ca>\n"
+"Language: fr\n"
+"Language-Team: \n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.8.0\n"
-"Plural-Forms: nplurals=2; plural=(n > 1);\n"
-"Last-Translator: Bob Swift <bswift@rsds.ca>\n"
-"Language-Team: \n"
-"Language: fr\n"
-"X-Generator: Poedit 2.4.1\n"
+"X-Generator: Poedit 2.4.2\n"
 
-#: ../../functions/func_rsearch.rst:7
+#: ../../functions/func_rsearch.rst:4
 msgid "$rsearch"
 msgstr "$rsearch"
 
-#: ../../functions/func_rsearch.rst:9
+#: ../../functions/func_rsearch.rst:6
 msgid "Usage: **$rsearch(text,pattern)**"
 msgstr "Utilisation: **$rsearch(texte,motif)**"
 
-#: ../../functions/func_rsearch.rst:10
+#: ../../functions/func_rsearch.rst:7
 msgid "Category: text"
 msgstr "Catégorie: texte"
 
-#: ../../functions/func_rsearch.rst:12
+#: ../../functions/func_rsearch.rst:9
 msgid "**Description:**"
 msgstr "**La description:**"
 
-#: ../../functions/func_rsearch.rst:14
+#: ../../functions/func_rsearch.rst:11
 msgid ""
 "Regular expression search. This function will return the first matching "
 "group specified by ``pattern`` from ``text``.  For more information "
@@ -49,10 +49,29 @@ msgstr ""
 "`l'article sur Wikipedia <https://wikipedia.org/wiki/"
 "Regular_expression>`_."
 
-#: ../../functions/func_rsearch.rst:19
+#: ../../functions/func_rsearch.rst:17
+msgid ""
+"When entering regular expressions into Picard scripts you have to escape "
+"a backslash \"\\\\\", dollar sign \"$\", comma \",\" and the left and "
+"right parentheses \"(\" and \")\" in order to force Picard to not "
+"interpret them as part of the script command.  This is done by inserting "
+"a backslash before the character to be escaped.  For example, the "
+"regular expression ``^\\s*([0-9,\\.]*)$`` would have to be entered as ``^"
+"\\\\s*\\([0-9\\,\\\\.]*\\)\\$``."
+msgstr ""
+"Lors de la saisie d'expressions régulières dans des scripts Picard, vous "
+"devez échapper une barre oblique inverse \"\\\\\", un signe dollar \"$"
+"\", une virgule \",\" et les parenthèses gauche et droite \"(\" et \")\" "
+"pour forcer Picard à ne pas les interpréter dans le cadre de la commande "
+"de script. Cela se fait en insérant une barre oblique inverse avant le "
+"caractère à échapper. Par exemple, l'expression régulière ``^\\s*([0-9,"
+"\\.]*)$`` devrait être saisie sous la forme ``^\\\\s*\\([0-9\\,\\\\.]*"
+"\\)\\$``."
+
+#: ../../functions/func_rsearch.rst:23
 msgid "**Example:**"
 msgstr "**Exemple:**"
 
-#: ../../functions/func_rsearch.rst:21
+#: ../../functions/func_rsearch.rst:25
 msgid "The following statements will return the values indicated::"
 msgstr "Les instructions suivantes renverront les valeurs indiquées::"

--- a/extending/scripting.rst
+++ b/extending/scripting.rst
@@ -28,8 +28,13 @@ alphanumeric characters enclosed in percent signs (e.g.: ``%artist%``). Function
 start with a dollar sign and end with an argument list enclosed in parentheses (e.g.:
 ``$lower(...)``).
 
-To use parentheses or commas as-is inside a function call, you must escape them with
-a backslash.
+.. note::
+
+   When entering input strings into Picard scripts you have to escape a backslash "\\",
+   dollar sign "$", comma "," and the left and right parentheses "(" and ")" in order to force
+   Picard to not interpret them as part of the script command.  This is done by inserting
+   a backslash before the character to be escaped.  For example, to set a tag value to ``($1,000,000)``
+   it would have to be entered as ``$set(test_tag,\(\$1\,000\,000\))``.
 
 Metadata Variables
 ------------------

--- a/functions/func_rreplace.rst
+++ b/functions/func_rreplace.rst
@@ -12,6 +12,13 @@ Regular expression replace. This function will replace the matching group specif
 ``pattern`` with ``replace`` in ``text``.  For more information about regular expressions,
 please see the `article on Wikipedia <https://wikipedia.org/wiki/Regular_expression>`_.
 
+.. note::
+
+   When entering regular expressions into Picard scripts you have to escape a backslash "\\",
+   dollar sign "$", comma "," and the left and right parentheses "(" and ")" in order to force
+   Picard to not interpret them as part of the script command.  This is done by inserting
+   a backslash before the character to be escaped.  For example, the regular expression
+   ``^\s*([0-9,\.]*)$`` would have to be entered as ``^\\s*\([0-9\,\\.]*\)\$``.
 
 **Example:**
 

--- a/functions/func_rsearch.rst
+++ b/functions/func_rsearch.rst
@@ -12,6 +12,13 @@ Regular expression search. This function will return the first matching group sp
 ``pattern`` from ``text``.  For more information about regular expressions, please see the
 `article on Wikipedia <https://wikipedia.org/wiki/Regular_expression>`_.
 
+.. note::
+
+   When entering regular expressions into Picard scripts you have to escape a backslash "\\",
+   dollar sign "$", comma "," and the left and right parentheses "(" and ")" in order to force
+   Picard to not interpret them as part of the script command.  This is done by inserting
+   a backslash before the character to be escaped.  For example, the regular expression
+   ``^\s*([0-9,\.]*)$`` would have to be entered as ``^\\s*\([0-9\,\\.]*\)\$``.
 
 **Example:**
 


### PR DESCRIPTION
<!--
    Thank-you for submitting a pull request. Your effort and input is appreciated.

    Please use this template to help us review your change. Not everything is
    required for every change, so please feel free to omit any sections that
    are not relevant to your change.

    Also, please ensure that you've reviewed the guidelines in CONTRIBUTING.md.
-->

### Summary

This is a…

- [ ] Correction
- [x] Addition
- [ ] Restructuring
- [ ] Minor / simple change (like a typo)
- [ ] Other

### Reason for the Change

There seems to be some confusion with users entering regular expressions.  If they don't understand the need to escape certain characters, it can be a source of frustration.

### Description of the Change

Add a note to the `$rreplace()` and `$rsearch()` scripting functions about the need to escape certain characters to prevent Picard from trying to interpret them as part of the script functions.

### Additional Action Required

Confirm that all characters required to be escaped are listed in the note.  The note includes the backslash and the opening and closing parentheses.  Should it also include the comma and dollar sign?
