### PR TITLE
Add redirection to new location of scripting.html

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 /docs/
 /images/
 __pycache__/
+/_ignored/

--- a/404.html
+++ b/404.html
@@ -33,99 +33,118 @@
       var has_version = false;
       var has_language = false;
       var has_rtd_format = false;
+      var well_formed = true;
+
+      var debug = false;
 
       const re_language = /^[a-z][a-z](-[A-Z][A-Z])?$/;
       const re_version1 = /^[0-9][0-9\.]*$/;
       const re_version2 = /^v[0-9][0-9\.]*$/;
 
       function is_language(test_language) {
-         // window.alert("Testing language: " + test_language);
+         if (debug) { window.alert("Testing language: " + test_language); }
          if (test_language.search(re_language) < 0) {
-            // window.alert("Failed regular expression check.");
+            if (debug) { window.alert("Failed regular expression check."); }
             return false;
          }
          if (supported_languages.indexOf(test_language) < 0) {
-            // window.alert("Failed supported languages check.");
+            if (debug) { window.alert("Failed supported languages check."); }
             return false;
          }
          target_language = test_language;
          has_language = true;
-         // window.alert("Passed.  Target language set to: " + target_language);
+         if (debug) { window.alert("Passed.  Target language set to: " + target_language); }
          return true;
       }
 
       function is_rtd_version(test_version) {
-         // window.alert("Testing RTD version: " + test_version);
+         if (debug) { window.alert("Testing RTD version: " + test_version); }
          if (test_version.search(re_version1) < 0) {
-            // window.alert("Failed regular expression check.");
+            if (debug) { window.alert("Failed regular expression check."); }
             return false;
          }
          if (version_list.indexOf(test_version) < 0) {
-            // window.alert("Failed supported versions check.");
+            if (debug) { window.alert("Failed supported versions check."); }
             return false;
          }
-         target_version = 'v' + test_version;
+         target_version = '/v' + test_version;
          has_version = true;
          has_rtd_format = true;
-         // window.alert("Passed. Target version set to: " + target_version);
+         if (debug) { window.alert("Passed. Target version set to: " + target_version); }
          return true;
       }
 
       function is_gh_version(test_version) {
-         // window.alert("Testing GH version: " + test_version);
+         if (debug) { window.alert("Testing GH version: " + test_version); }
          if (test_version.search(re_version2) < 0) {
-            // window.alert("Failed regular expression check.");
+            if (debug) { window.alert("Failed regular expression check."); }
             return false;
          }
          var temp = test_version.substring(1);
          if (version_list.indexOf(temp) < 0) {
-            // window.alert("Failed supported versions check.");
-            return false;
+            if (debug) { window.alert("Failed supported versions check."); }
+            target_version = '';
+            // has_version = true;
+            return true;
          }
-         target_version = test_version;
+         target_version = '/' + test_version;
          has_version = true;
-         // window.alert("Passed. Target version set to: " + target_version);
+         if (debug) { window.alert("Passed. Target version set to: " + target_version); }
          return true;
       }
 
       var counter = 1;
-      if (is_language(src_path_parts[counter])) {
+      // Check for GitHub Pages style version number
+      if (is_gh_version(src_path_parts[counter])) {
+         target_path = target_version;
          counter += 1;
-         if (counter < src_path_parts.length) {
-            if ((is_rtd_version(src_path_parts[counter])) || (src_path_parts[counter].search(/^(latest|stable)$/) >= 0)) {
-               if (is_rtd_version(src_path_parts[counter])) {
-                  target_path = '/' + target_version;
-               }
-               else {
-                  if (src_path_parts[counter] == 'stable') {
-                     target_path = '/v' + latest_version;
-                  }
-               }
-               counter += 1;
-               target_path += '/' + target_language;
-               while (counter < src_path_parts.length) {
-                  target_path += '/' + src_path_parts[counter];
-                  counter += 1;
-               }
-               target_url = src_protocol + '//' + src_host + target_path;
+      }
+
+      // Check for language identifier
+      if (is_language(src_path_parts[counter])) {
+         target_path += '/' + target_language;
+         counter += 1;
+      }
+
+      // Check for ReadTheDocs style version number
+      if ((!has_version) && ((is_rtd_version(src_path_parts[counter])) || (src_path_parts[counter].search(/^(latest|stable)$/) >= 0))) {
+         if (is_rtd_version(src_path_parts[counter])) {
+            target_path = target_version + '/' + target_language;
+         }
+         else {
+            if (src_path_parts[counter] == 'stable') {
+               target_path = '/v' + latest_version + '/' + target_language;
             }
          }
-         if (target_url == '') {
-            target_url = src_protocol + '//' + src_host + '/' + target_language + '/not_found.html';
+         well_formed = false;
+         counter += 1;
+      }
+
+      // Patch to redirect to new location of scripting documentation
+      if (src_path_parts[counter] == 'scripting.html') {
+         target_path += '/extending';
+         if (debug) { window.alert("Patching target url for updated location of scripting.html file."); }
+         if ((has_language) || (has_version)) {
+            well_formed = false;
          }
+      }
+
+      // Combine remaining portions of the submitted path
+      while (counter < src_path_parts.length) {
+         target_path += '/' + src_path_parts[counter];
+         counter += 1;
+      }
+
+      // Build the redirection target url
+      if (well_formed) {
+         target_url = src_protocol + '//' + src_host + target_version + '/' + target_language + '/not_found.html';
       }
       else {
-         if (is_gh_version(src_path_parts[counter])) {
-            counter += 1;
-            if (is_language(src_path_parts[counter])) {
-               target_url = src_protocol + '//' + src_host + '/' + target_version + '/' + target_language + '/not_found.html';
-            }
-         }
-         if (target_url == '') {
-            target_url = src_protocol + '//' + src_host + '/' + target_language + '/not_found.html';
-         }
+         target_url = src_protocol + '//' + src_host + target_path;
       }
-      // window.alert('Old URL: ' + window.location + "\nNew URL: " + target_url)
+
+      // Redirect to the new target
+      if (debug) { window.alert('Old URL: ' + window.location + "\nNew URL: " + target_url); }
       window.location.replace(target_url);
    </script>
 </body>

--- a/404_template.html
+++ b/404_template.html
@@ -34,98 +34,116 @@
       var has_language = false;
       var has_rtd_format = false;
 
+      var debug = false;
+
       const re_language = /^[a-z][a-z](-[A-Z][A-Z])?$/;
       const re_version1 = /^[0-9][0-9\.]*$/;
       const re_version2 = /^v[0-9][0-9\.]*$/;
 
       function is_language(test_language) {
-         // window.alert("Testing language: " + test_language);
+         if (debug) { window.alert("Testing language: " + test_language); }
          if (test_language.search(re_language) < 0) {
-            // window.alert("Failed regular expression check.");
+            if (debug) { window.alert("Failed regular expression check."); }
             return false;
          }
          if (supported_languages.indexOf(test_language) < 0) {
-            // window.alert("Failed supported languages check.");
+            if (debug) { window.alert("Failed supported languages check."); }
             return false;
          }
          target_language = test_language;
          has_language = true;
-         // window.alert("Passed.  Target language set to: " + target_language);
+         if (debug) { window.alert("Passed.  Target language set to: " + target_language); }
          return true;
       }
 
       function is_rtd_version(test_version) {
-         // window.alert("Testing RTD version: " + test_version);
+         if (debug) { window.alert("Testing RTD version: " + test_version); }
          if (test_version.search(re_version1) < 0) {
-            // window.alert("Failed regular expression check.");
+            if (debug) { window.alert("Failed regular expression check."); }
             return false;
          }
          if (version_list.indexOf(test_version) < 0) {
-            // window.alert("Failed supported versions check.");
+            if (debug) { window.alert("Failed supported versions check."); }
             return false;
          }
-         target_version = 'v' + test_version;
+         target_version = '/v' + test_version;
          has_version = true;
          has_rtd_format = true;
-         // window.alert("Passed. Target version set to: " + target_version);
+         if (debug) { window.alert("Passed. Target version set to: " + target_version); }
          return true;
       }
 
       function is_gh_version(test_version) {
-         // window.alert("Testing GH version: " + test_version);
+         if (debug) { window.alert("Testing GH version: " + test_version); }
          if (test_version.search(re_version2) < 0) {
-            // window.alert("Failed regular expression check.");
+            if (debug) { window.alert("Failed regular expression check."); }
             return false;
          }
          var temp = test_version.substring(1);
          if (version_list.indexOf(temp) < 0) {
-            // window.alert("Failed supported versions check.");
-            return false;
+            if (debug) { window.alert("Failed supported versions check."); }
+            target_version = '';
+            // has_version = true;
+            return true;
          }
-         target_version = test_version;
+         target_version = '/' + test_version;
          has_version = true;
-         // window.alert("Passed. Target version set to: " + target_version);
+         if (debug) { window.alert("Passed. Target version set to: " + target_version); }
          return true;
       }
 
       var counter = 1;
-      if (is_language(src_path_parts[counter])) {
+      // Check for GitHub Pages style version number
+      if (is_gh_version(src_path_parts[counter])) {
+         target_path = target_version;
          counter += 1;
-         if (counter < src_path_parts.length) {
-            if ((is_rtd_version(src_path_parts[counter])) || (src_path_parts[counter].search(/^(latest|stable)$/) >= 0)) {
-               if (is_rtd_version(src_path_parts[counter])) {
-                  target_path = '/' + target_version;
-               }
-               else {
-                  if (src_path_parts[counter] == 'stable') {
-                     target_path = '/v' + latest_version;
-                  }
-               }
-               counter += 1;
-               target_path += '/' + target_language;
-               while (counter < src_path_parts.length) {
-                  target_path += '/' + src_path_parts[counter];
-                  counter += 1;
-               }
-               target_url = src_protocol + '//' + src_host + target_path;
+      }
+
+      // Check for language identifier
+      if (is_language(src_path_parts[counter])) {
+         target_path += '/' + target_language;
+         counter += 1;
+      }
+
+      // Check for ReadTheDocs style version number
+      if ((!has_version) && ((is_rtd_version(src_path_parts[counter])) || (src_path_parts[counter].search(/^(latest|stable)$/) >= 0))) {
+         if (is_rtd_version(src_path_parts[counter])) {
+            target_path = target_version + '/' + target_language;
+         }
+         else {
+            if (src_path_parts[counter] == 'stable') {
+               target_path = '/v' + latest_version + '/' + target_language;
             }
          }
-         if (target_url == '') {
-            target_url = src_protocol + '//' + src_host + '/' + target_language + '/not_found.html';
+         well_formed = false;
+         counter += 1;
+      }
+
+      // Patch to redirect to new location of scripting documentation
+      if (src_path_parts[counter] == 'scripting.html') {
+         target_path += '/extending';
+         if (debug) { window.alert("Patching target url for updated location of scripting.html file."); }
+         if ((has_language) || (has_version)) {
+            well_formed = false;
          }
+      }
+
+      // Combine remaining portions of the submitted path
+      while (counter < src_path_parts.length) {
+         target_path += '/' + src_path_parts[counter];
+         counter += 1;
+      }
+
+      // Build the redirection target url
+      if (well_formed) {
+         target_url = src_protocol + '//' + src_host + target_version + '/' + target_language + '/not_found.html';
       }
       else {
-         if (is_gh_version(src_path_parts[counter])) {
-            counter += 1;
-            if (is_language(src_path_parts[counter])) {
-               target_url = src_protocol + '//' + src_host + '/' + target_version + '/' + target_language + '/not_found.html';
-            }
-         }
-         if (target_url == '') {
-            target_url = src_protocol + '//' + src_host + '/' + target_language + '/not_found.html';
-         }
+         target_url = src_protocol + '//' + src_host + target_path;
       }
-      // window.alert('Old URL: ' + window.location + "\nNew URL: " + target_url)
+
+      // Redirect to the new target
+      if (debug) { window.alert('Old URL: ' + window.location + "\nNew URL: " + target_url); }
       window.location.replace(target_url);
    </script>
 </body>


### PR DESCRIPTION
<!--
    Thank-you for submitting a pull request. Your effort and input is appreciated.

    Please use this template to help us review your change. Not everything is
    required for every change, so please feel free to omit any sections that
    are not relevant to your change.

    Also, please ensure that you've reviewed the guidelines in CONTRIBUTING.md.
-->

### Summary

This is a…

- [x] Correction
- [ ] Addition
- [ ] Restructuring
- [ ] Minor / simple change (like a typo)
- [ ] Other

### Reason for the Change

The location of the `scripting.html` file was changed, causing the link from Picard to break.  This was reported in issue #66.

### Description of the Change

Update the redirection logic in the `404.html` file to redirect calls to the old location of `scripting.html` to its new location.  Fixes #66. 

### Additional Action Required

None.
