### PR TITLE
download: Clarify giving Picard Snap access to removable media

### DIFF
--- a/faq/faq_usage.rst
+++ b/faq/faq_usage.rst
@@ -41,12 +41,14 @@ following:
       <https://musicbrainz.org/doc/How_to_Add_a_Release>`_, supplying evidence of the track listing and as much information
       as possible to prove it is genuine and it may be accepted again.
 
+
 I'm using macOS, where are my :index:`network folders <macos; network folders>` or drives?
 ---------------------------------------------------------------------------------------------
 
 These should show up in the add file and add folder dialogs, but they aren't visible by default in the file browser
 pane. If you want to see them in the file browser pane, right click in the pane and select "show hidden files". They
 should then be visible in the /Volumes folder.
+
 
 macOS shows the app is :index:`damaged <macos; app damaged>`. How can I run Picard?
 --------------------------------------------------------------------------------------
@@ -64,3 +66,15 @@ and run::
 
 This will clear the app being marked as damaged.  If you have placed the app in a different
 location than :file:`/Applications` adjust the path in the command above accordingly.
+
+
+Picard is installed on Linux as a Snap, how can I access removable media?
+-------------------------------------------------------------------------
+
+Picard installed as a Snap is running inside a sandbox and thus it does not have full access to all files and
+folders on your system.  By default Picard has access to your home folder.  You can additionally give it access to
+removable media by running the following command on a terminal:
+
+.. code-block:: bash
+
+   snap connect picard:removable-media

--- a/getting_started/download.rst
+++ b/getting_started/download.rst
@@ -49,12 +49,22 @@ Picard is available as a Snap from the Snap Store.  This version should work on 
 Linux distributions, as long as Snap is installed (see `Installing Snap <https://snapcraft.io/docs/installing-snapd>`_).
 
 If your Linux distributions supports it you can install Picard from your distribution's software
-center, e.g. Ubuntu Software or KDE Discover.  You can also install Picard from the command line:
+center, e.g. Ubuntu Software or KDE Discover.  You can also install Picard from the terminal:
 
 
 .. code-block:: bash
 
    snap install picard
+
+.. note::
+
+   Picard installed as a Snap is running inside a sandbox and thus it does not have full access to all files and
+   folders on your system.  By default Picard has access to your home folder.  You can additionally give it access to
+   removable media by running the following command on a terminal:
+
+   .. code-block:: bash
+
+      snap connect picard:removable-media
 
 
 :index:`Installing from your distribution's package repository <pair: install; Linux package>`


### PR DESCRIPTION
<!--
    Thank-you for submitting a pull request. Your effort and input is appreciated.

    Please use this template to help us review your change. Not everything is
    required for every change, so please feel free to omit any sections that
    are not relevant to your change.

    Also, please ensure that you've reviewed the guidelines in CONTRIBUTING.md.
-->

### Summary

This is a…

- [ ] Correction
- [x] Addition
- [ ] Restructuring
- [ ] Minor / simple change (like a typo)
- [ ] Other

### Reason for the Change

The Linux Snap version does not have access to removable drives by default, but can be enabled. As this might not be clear that this is the case and that this can be changed document this.

### Description of the Change

Document how to grant Picard access to removable drives on the download page. Also add a FAQ entry.
