### PR TITLE
Quick FR fixes

### DIFF
--- a/_locale/fr/LC_MESSAGES/genindex.po
+++ b/_locale/fr/LC_MESSAGES/genindex.po
@@ -21,4 +21,4 @@ msgstr ""
 
 #: ../../genindex.rst:4
 msgid "Index"
-msgstr "Indice"
+msgstr "Index"

--- a/_locale/fr/LC_MESSAGES/sphinx.po
+++ b/_locale/fr/LC_MESSAGES/sphinx.po
@@ -38,11 +38,11 @@ msgstr "Afficher la source de la page"
 
 #: ../../_templates/breadcrumbs.html:74 ../../_templates/footer.html:5
 msgid "Next"
-msgstr "Prochain"
+msgstr "Page suivante"
 
 #: ../../_templates/breadcrumbs.html:77 ../../_templates/footer.html:8
 msgid "Previous"
-msgstr "Précédent"
+msgstr "Page précédente"
 
 #: ../../_templates/footer.html:17
 msgid "This MusicBrainz Picard User Guide is licensed under CC0 1.0"
@@ -81,7 +81,7 @@ msgstr "fourni par %(readthedocs_web)s"
 
 #: ../../_templates/versions.html:12
 msgid "Versions"
-msgstr "Révision"
+msgstr "Révisions"
 
 #: ../../_templates/versions.html:19 ../../_templates/versions.html:63
 msgid "Downloads"
@@ -97,7 +97,7 @@ msgstr "Accueil du projet"
 
 #: ../../_templates/versions.html:32
 msgid "Builds"
-msgstr "Les gabarit"
+msgstr "Les gabarits"
 
 #: ../../_templates/versions.html:42
 msgid "Options"
@@ -105,7 +105,7 @@ msgstr "Options"
 
 #: ../../_templates/versions.html:48
 msgid "Select Version"
-msgstr "Sélectionnez la version"
+msgstr "Sélectionner la version"
 
 #: ../../_templates/versions.html:52
 msgid "Select Language"

--- a/conf.py
+++ b/conf.py
@@ -41,9 +41,9 @@ copyright = 'This documentation is licensed under CC0 1.0.'     # pylint: disabl
 default_language = 'en'
 supported_languages = [
     ('en', 'English'),
-    ('fr', 'Française'),
-    # ('de', 'Deutsche'),
-    # ('es', 'Española'),
+    ('fr', 'Français'),
+    # ('de', 'Deutsch'),
+    # ('es', 'Español'),
 ]
 
 # -- Base file name for PDF and EPUB files -----------------------------------


### PR DESCRIPTION
<!--
    Thank-you for submitting a pull request. Your effort and input is appreciated.

    Please use this template to help us review your change. Not everything is
    required for every change, so please feel free to omit any sections that
    are not relevant to your change.

    Also, please ensure that you've reviewed the guidelines in CONTRIBUTING.md.
-->

### Summary

This is a…

- [ ] Correction
- [ ] Addition
- [ ] Restructuring
- [x] Minor / simple change (like a typo)
- [ ] Other

### Reason for the Change

Some things appeared slightly unnatural in the French navigation (left sidebar and pagination buttons).

### Description of the Change

We would not select the French language (la langue française) but French as language (je choisis le français comme langue).
Also for consistency, I put infinitive verb.
*Précédent* (Previous) was OK but *Prochain* (Next) was quite strange.
So I replaced by the translation of previous page and next page.


### Additional Action Required

I was reviewing the bigger FR files when I stopped because I wondered if maybe those changes have to be done in something like Transifex, instead of a PR.
So I committed only the small files, in case it's not the way to go.
I am never keen to use Transifex, BTW.