### PR TITLE
Add keyboard shortcuts to PDF builder.  Add French translation.

### DIFF
--- a/_locale/fr/LC_MESSAGES/appendices/keyboard_shortcuts.po
+++ b/_locale/fr/LC_MESSAGES/appendices/keyboard_shortcuts.po
@@ -1,0 +1,426 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) This documentation is licensed under CC0 1.0.
+# This file is distributed under the same license as the MusicBrainz Picard
+# package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2021.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: MusicBrainz Picard v2.6\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2021-03-30 11:04-0600\n"
+"PO-Revision-Date: 2021-03-31 16:35-0600\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.8.0\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+"Last-Translator: Bob Swift <bswift@rsds.ca>\n"
+"Language-Team: \n"
+"Language: fr\n"
+"X-Generator: Poedit 2.4.2\n"
+
+#: ../../appendices/keyboard_shortcuts.rst:9
+msgid ""
+"Appendix D: :index:`Keyboard Shortcuts <user interface; keyboard "
+"shortcuts>`"
+msgstr ""
+"Annexe D: :index:`Courts clavier <interface utilisateur ; "
+"raccourcis clavier>`"
+
+#: ../../appendices/keyboard_shortcuts.rst:12
+msgid "Main window"
+msgstr "Fenêtre principale"
+
+#: ../../appendices/keyboard_shortcuts.rst:19
+#: ../../appendices/keyboard_shortcuts.rst:82
+msgid "Action"
+msgstr "Action"
+
+#: ../../appendices/keyboard_shortcuts.rst:19
+#: ../../appendices/keyboard_shortcuts.rst:82
+msgid "Windows / Linux"
+msgstr "Windows / Linux"
+
+#: ../../appendices/keyboard_shortcuts.rst:19
+#: ../../appendices/keyboard_shortcuts.rst:82
+msgid "macOS"
+msgstr "macOS"
+
+#: ../../appendices/keyboard_shortcuts.rst:21
+msgid "**File**"
+msgstr "**Fichier**"
+
+#: ../../appendices/keyboard_shortcuts.rst:23
+msgid "Add folder"
+msgstr "Ajouter un dossier"
+
+#: ../../appendices/keyboard_shortcuts.rst:23
+msgid "Ctrl+E"
+msgstr ""
+
+#: ../../appendices/keyboard_shortcuts.rst:23
+msgid "⌘+E"
+msgstr ""
+
+#: ../../appendices/keyboard_shortcuts.rst:24
+msgid "Add files"
+msgstr "Ajouter des fichiers"
+
+#: ../../appendices/keyboard_shortcuts.rst:24
+msgid "Ctrl+O"
+msgstr ""
+
+#: ../../appendices/keyboard_shortcuts.rst:24
+msgid "⌘+O"
+msgstr ""
+
+#: ../../appendices/keyboard_shortcuts.rst:25
+msgid "Save selected files"
+msgstr "Sauvegarder les fichiers sélectionnés"
+
+#: ../../appendices/keyboard_shortcuts.rst:25
+msgid "Ctrl+S"
+msgstr ""
+
+#: ../../appendices/keyboard_shortcuts.rst:25
+msgid "⌘+S"
+msgstr ""
+
+#: ../../appendices/keyboard_shortcuts.rst:26
+msgid "Quit Picard"
+msgstr "Quitter Picard"
+
+#: ../../appendices/keyboard_shortcuts.rst:26
+msgid "Ctrl+Q"
+msgstr ""
+
+#: ../../appendices/keyboard_shortcuts.rst:26
+msgid "⌘+Q"
+msgstr ""
+
+#: ../../appendices/keyboard_shortcuts.rst:28
+msgid "**Edit**"
+msgstr "Modifier"
+
+#: ../../appendices/keyboard_shortcuts.rst:30
+msgid "Cut selected files"
+msgstr "Couper les fichiers sélectionnés"
+
+#: ../../appendices/keyboard_shortcuts.rst:30
+msgid "Ctrl+X"
+msgstr ""
+
+#: ../../appendices/keyboard_shortcuts.rst:30
+msgid "⌘+X"
+msgstr ""
+
+#: ../../appendices/keyboard_shortcuts.rst:31
+msgid "Paste selected files"
+msgstr "Coller les fichiers sélectionnés"
+
+#: ../../appendices/keyboard_shortcuts.rst:31
+#: ../../appendices/keyboard_shortcuts.rst:64
+msgid "Ctrl+V"
+msgstr ""
+
+#: ../../appendices/keyboard_shortcuts.rst:31
+#: ../../appendices/keyboard_shortcuts.rst:64
+msgid "⌘+V"
+msgstr ""
+
+#: ../../appendices/keyboard_shortcuts.rst:32
+msgid "Show info for selected item"
+msgstr "Afficher les informations sur l'élément sélectionné"
+
+#: ../../appendices/keyboard_shortcuts.rst:32
+msgid "Ctrl+I"
+msgstr ""
+
+#: ../../appendices/keyboard_shortcuts.rst:32
+msgid "⌘+I"
+msgstr ""
+
+#: ../../appendices/keyboard_shortcuts.rst:34
+msgid "**View**"
+msgstr "Voir"
+
+#: ../../appendices/keyboard_shortcuts.rst:36
+msgid "Toggle file browser"
+msgstr "Basculer le navigateur de fichiers"
+
+#: ../../appendices/keyboard_shortcuts.rst:36
+msgid "Ctrl+B"
+msgstr ""
+
+#: ../../appendices/keyboard_shortcuts.rst:36
+msgid "⌘+B"
+msgstr ""
+
+#: ../../appendices/keyboard_shortcuts.rst:38
+msgid "**Tools**"
+msgstr "**Outils**"
+
+#: ../../appendices/keyboard_shortcuts.rst:40
+msgid "Refresh"
+msgstr "Rafraîchir"
+
+#: ../../appendices/keyboard_shortcuts.rst:40
+msgid "Ctrl+R"
+msgstr ""
+
+#: ../../appendices/keyboard_shortcuts.rst:40
+msgid "⌘+R"
+msgstr ""
+
+#: ../../appendices/keyboard_shortcuts.rst:41
+msgid "Lookup CD"
+msgstr "CD de recherche"
+
+#: ../../appendices/keyboard_shortcuts.rst:41
+msgid "Ctrl+K"
+msgstr ""
+
+#: ../../appendices/keyboard_shortcuts.rst:41
+msgid "⌘+K"
+msgstr ""
+
+#: ../../appendices/keyboard_shortcuts.rst:42
+msgid "Lookup"
+msgstr "Consulter le site"
+
+#: ../../appendices/keyboard_shortcuts.rst:42
+msgid "Ctrl+L"
+msgstr ""
+
+#: ../../appendices/keyboard_shortcuts.rst:42
+msgid "⌘+L"
+msgstr ""
+
+#: ../../appendices/keyboard_shortcuts.rst:43
+msgid "Scan"
+msgstr "Scanner"
+
+#: ../../appendices/keyboard_shortcuts.rst:43
+msgid "Ctrl+Y"
+msgstr ""
+
+#: ../../appendices/keyboard_shortcuts.rst:43
+msgid "⌘+Y"
+msgstr ""
+
+#: ../../appendices/keyboard_shortcuts.rst:44
+msgid "Cluster"
+msgstr "Cluster"
+
+#: ../../appendices/keyboard_shortcuts.rst:44
+msgid "Ctrl+U"
+msgstr ""
+
+#: ../../appendices/keyboard_shortcuts.rst:44
+msgid "⌘+U"
+msgstr ""
+
+#: ../../appendices/keyboard_shortcuts.rst:45
+msgid "Lookup in browser"
+msgstr "Recherche dans le navigateur"
+
+#: ../../appendices/keyboard_shortcuts.rst:45
+msgid "Ctrl+Shift+L"
+msgstr ""
+
+#: ../../appendices/keyboard_shortcuts.rst:45
+msgid "⌘+⇧+L"
+msgstr ""
+
+#: ../../appendices/keyboard_shortcuts.rst:46
+msgid "Search for similar tracks"
+msgstr "Rechercher des pistes similaires"
+
+#: ../../appendices/keyboard_shortcuts.rst:46
+msgid "Ctrl+T"
+msgstr ""
+
+#: ../../appendices/keyboard_shortcuts.rst:46
+msgid "⌘+T"
+msgstr ""
+
+#: ../../appendices/keyboard_shortcuts.rst:47
+msgid "Generate AcoustID fingerprints"
+msgstr "Générer des empreintes digitales AcoustID"
+
+#: ../../appendices/keyboard_shortcuts.rst:47
+msgid "Ctrl+Shift+Y"
+msgstr ""
+
+#: ../../appendices/keyboard_shortcuts.rst:47
+msgid "⌘+⇧+Y"
+msgstr ""
+
+#: ../../appendices/keyboard_shortcuts.rst:48
+msgid "Tags from file names"
+msgstr "Balises à partir des noms de fichiers"
+
+#: ../../appendices/keyboard_shortcuts.rst:48
+msgid "Ctrl+Shift+T"
+msgstr ""
+
+#: ../../appendices/keyboard_shortcuts.rst:48
+msgid "⌘+⇧+T"
+msgstr ""
+
+#: ../../appendices/keyboard_shortcuts.rst:50
+msgid "**Help**"
+msgstr "**Aide**"
+
+#: ../../appendices/keyboard_shortcuts.rst:52
+msgid "Help"
+msgstr "Aide"
+
+#: ../../appendices/keyboard_shortcuts.rst:52
+msgid "F1"
+msgstr ""
+
+#: ../../appendices/keyboard_shortcuts.rst:52
+msgid "⌘+?"
+msgstr ""
+
+#: ../../appendices/keyboard_shortcuts.rst:53
+msgid "View activity history"
+msgstr "Afficher l'historique des activités"
+
+#: ../../appendices/keyboard_shortcuts.rst:53
+msgid "Ctrl+H"
+msgstr ""
+
+#: ../../appendices/keyboard_shortcuts.rst:53
+msgid "⌘+⇧+H"
+msgstr ""
+
+#: ../../appendices/keyboard_shortcuts.rst:54
+msgid "View error/debug log"
+msgstr "Afficher le journal d'erreur/débogage"
+
+#: ../../appendices/keyboard_shortcuts.rst:54
+msgid "Ctrl+G"
+msgstr ""
+
+#: ../../appendices/keyboard_shortcuts.rst:54
+msgid "⌘+G"
+msgstr ""
+
+#: ../../appendices/keyboard_shortcuts.rst:56
+msgid "**Metadata view**"
+msgstr "**Vue des métadonnées**"
+
+#: ../../appendices/keyboard_shortcuts.rst:58
+msgid "Add new tag"
+msgstr "Ajouter un nouveau tag"
+
+#: ../../appendices/keyboard_shortcuts.rst:58
+msgid "Alt+Shift+A"
+msgstr ""
+
+#: ../../appendices/keyboard_shortcuts.rst:58
+msgid "⌥+⇧+A"
+msgstr ""
+
+#: ../../appendices/keyboard_shortcuts.rst:59
+msgid "Edit selected tag"
+msgstr "Modifier la balise sélectionnée"
+
+#: ../../appendices/keyboard_shortcuts.rst:59
+msgid "Alt+Shift+E"
+msgstr ""
+
+#: ../../appendices/keyboard_shortcuts.rst:59
+msgid "⌥+⇧+E"
+msgstr ""
+
+#: ../../appendices/keyboard_shortcuts.rst:60
+msgid "Remove selected tag"
+msgstr "Supprimer la balise sélectionnée"
+
+#: ../../appendices/keyboard_shortcuts.rst:60
+msgid "Alt+Shift+R |br| Del"
+msgstr ""
+
+#: ../../appendices/keyboard_shortcuts.rst:60
+msgid "⌥+⇧+R |br| Del |br| ⌘+⌫"
+msgstr ""
+
+#: ../../appendices/keyboard_shortcuts.rst:63
+msgid "Copy selected tag value"
+msgstr "Copier la valeur de la balise sélectionnée"
+
+#: ../../appendices/keyboard_shortcuts.rst:63
+msgid "Ctrl+C"
+msgstr ""
+
+#: ../../appendices/keyboard_shortcuts.rst:63
+msgid "⌘+C"
+msgstr ""
+
+#: ../../appendices/keyboard_shortcuts.rst:64
+msgid "Paste to selected tag value"
+msgstr "Coller à la valeur de la balise sélectionnée"
+
+#: ../../appendices/keyboard_shortcuts.rst:66
+msgid "**Other**"
+msgstr "**Autre**"
+
+#: ../../appendices/keyboard_shortcuts.rst:68
+msgid "Focus search"
+msgstr "Recherche ciblée"
+
+#: ../../appendices/keyboard_shortcuts.rst:68
+msgid "Ctrl+F"
+msgstr ""
+
+#: ../../appendices/keyboard_shortcuts.rst:68
+msgid "⌘+F"
+msgstr ""
+
+#: ../../appendices/keyboard_shortcuts.rst:69
+msgid "Remove selected item"
+msgstr "Supprimer l'élément sélectionné"
+
+#: ../../appendices/keyboard_shortcuts.rst:69
+msgid "Del"
+msgstr ""
+
+#: ../../appendices/keyboard_shortcuts.rst:69
+msgid "Del |br| ⌘+⌫"
+msgstr ""
+
+#: ../../appendices/keyboard_shortcuts.rst:75
+msgid "Script editor"
+msgstr "Éditeur de script"
+
+#: ../../appendices/keyboard_shortcuts.rst:84
+msgid "Show auto completion"
+msgstr "Afficher la complétion automatique"
+
+#: ../../appendices/keyboard_shortcuts.rst:84
+msgid "Ctrl+Space"
+msgstr ""
+
+#: ../../appendices/keyboard_shortcuts.rst:84
+msgid "⌃+Space"
+msgstr ""
+
+#: ../../appendices/keyboard_shortcuts.rst:85
+msgid "Use selected completion"
+msgstr "Utiliser l'achèvement sélectionné"
+
+#: ../../appendices/keyboard_shortcuts.rst:85
+msgid "Tab |br| Return"
+msgstr ""
+
+#: ../../appendices/keyboard_shortcuts.rst:87
+msgid "Hide completions"
+msgstr "Cacher les achèvements"
+
+#: ../../appendices/keyboard_shortcuts.rst:87
+msgid "Esc"
+msgstr ""

--- a/_locale/fr/LC_MESSAGES/appendices/keyboard_shortcuts_pdf.po
+++ b/_locale/fr/LC_MESSAGES/appendices/keyboard_shortcuts_pdf.po
@@ -1,0 +1,406 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) This documentation is licensed under CC0 1.0.
+# This file is distributed under the same license as the MusicBrainz Picard
+# package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2021.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: MusicBrainz Picard v2.6\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2021-03-31 16:18-0600\n"
+"PO-Revision-Date: 2021-03-31 16:41-0600\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.8.0\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+"Last-Translator: Bob Swift <bswift@rsds.ca>\n"
+"Language-Team: \n"
+"Language: fr\n"
+"X-Generator: Poedit 2.4.2\n"
+
+#: ../../appendices/keyboard_shortcuts_pdf.rst:8
+msgid ""
+"Appendix D: :index:`Keyboard Shortcuts <user interface; keyboard "
+"shortcuts>`"
+msgstr ""
+"Annexe D: :index:`Courts clavier <interface utilisateur ; "
+"raccourcis clavier>`"
+
+#: ../../appendices/keyboard_shortcuts_pdf.rst:11
+msgid "Main window"
+msgstr "Fenêtre principale"
+
+#: ../../appendices/keyboard_shortcuts_pdf.rst:14
+msgid "File"
+msgstr "Fichier"
+
+#: ../../appendices/keyboard_shortcuts_pdf.rst:1
+msgid "**Action**"
+msgstr "**Action**"
+
+#: ../../appendices/keyboard_shortcuts_pdf.rst:1
+msgid "**Windows / Linux**"
+msgstr "**Windows / Linux**"
+
+#: ../../appendices/keyboard_shortcuts_pdf.rst:1
+msgid "**macOS**"
+msgstr "**macOS**"
+
+#: ../../appendices/keyboard_shortcuts_pdf.rst:1
+msgid "Add folder"
+msgstr "Ajouter un dossier"
+
+#: ../../appendices/keyboard_shortcuts_pdf.rst:1
+msgid "Ctrl+E"
+msgstr ""
+
+#: ../../appendices/keyboard_shortcuts_pdf.rst:1
+msgid "Cmd+E"
+msgstr ""
+
+#: ../../appendices/keyboard_shortcuts_pdf.rst:1
+msgid "Add files"
+msgstr "Ajouter des fichiers"
+
+#: ../../appendices/keyboard_shortcuts_pdf.rst:1
+msgid "Ctrl+O"
+msgstr ""
+
+#: ../../appendices/keyboard_shortcuts_pdf.rst:1
+msgid "Cmd+O"
+msgstr ""
+
+#: ../../appendices/keyboard_shortcuts_pdf.rst:1
+msgid "Save selected files"
+msgstr "Sauvegarder les fichiers sélectionnés"
+
+#: ../../appendices/keyboard_shortcuts_pdf.rst:1
+msgid "Ctrl+S"
+msgstr ""
+
+#: ../../appendices/keyboard_shortcuts_pdf.rst:1
+msgid "Cmd+S"
+msgstr ""
+
+#: ../../appendices/keyboard_shortcuts_pdf.rst:1
+msgid "Quit Picard"
+msgstr "Quitter Picard"
+
+#: ../../appendices/keyboard_shortcuts_pdf.rst:1
+msgid "Ctrl+Q"
+msgstr ""
+
+#: ../../appendices/keyboard_shortcuts_pdf.rst:1
+msgid "Cmd+Q"
+msgstr ""
+
+#: ../../appendices/keyboard_shortcuts_pdf.rst:27
+msgid "Edit"
+msgstr "Modifier"
+
+#: ../../appendices/keyboard_shortcuts_pdf.rst:1
+msgid "Cut selected files"
+msgstr "Couper les fichiers sélectionnés"
+
+#: ../../appendices/keyboard_shortcuts_pdf.rst:1
+msgid "Ctrl+X"
+msgstr ""
+
+#: ../../appendices/keyboard_shortcuts_pdf.rst:1
+msgid "Cmd+X"
+msgstr ""
+
+#: ../../appendices/keyboard_shortcuts_pdf.rst:1
+msgid "Paste selected files"
+msgstr "Coller les fichiers sélectionnés"
+
+#: ../../appendices/keyboard_shortcuts_pdf.rst:1
+msgid "Ctrl+V"
+msgstr ""
+
+#: ../../appendices/keyboard_shortcuts_pdf.rst:1
+msgid "Cmd+V"
+msgstr ""
+
+#: ../../appendices/keyboard_shortcuts_pdf.rst:1
+msgid "Show info for selected item"
+msgstr "Afficher les informations sur l'élément sélectionné"
+
+#: ../../appendices/keyboard_shortcuts_pdf.rst:1
+msgid "Ctrl+I"
+msgstr ""
+
+#: ../../appendices/keyboard_shortcuts_pdf.rst:1
+msgid "Cmd+I"
+msgstr ""
+
+#: ../../appendices/keyboard_shortcuts_pdf.rst:39
+msgid "View"
+msgstr "Voir"
+
+#: ../../appendices/keyboard_shortcuts_pdf.rst:1
+msgid "Toggle file browser"
+msgstr "Basculer le navigateur de fichiers"
+
+#: ../../appendices/keyboard_shortcuts_pdf.rst:1
+msgid "Ctrl+B"
+msgstr ""
+
+#: ../../appendices/keyboard_shortcuts_pdf.rst:1
+msgid "Cmd+B"
+msgstr ""
+
+#: ../../appendices/keyboard_shortcuts_pdf.rst:48
+msgid "Tools"
+msgstr "Outils"
+
+#: ../../appendices/keyboard_shortcuts_pdf.rst:1
+msgid "Refresh"
+msgstr "Rafraîchir"
+
+#: ../../appendices/keyboard_shortcuts_pdf.rst:1
+msgid "Ctrl+R"
+msgstr ""
+
+#: ../../appendices/keyboard_shortcuts_pdf.rst:1
+msgid "Cmd+R"
+msgstr ""
+
+#: ../../appendices/keyboard_shortcuts_pdf.rst:1
+msgid "Lookup CD"
+msgstr "CD de recherche"
+
+#: ../../appendices/keyboard_shortcuts_pdf.rst:1
+msgid "Ctrl+K"
+msgstr ""
+
+#: ../../appendices/keyboard_shortcuts_pdf.rst:1
+msgid "Cmd+K"
+msgstr ""
+
+#: ../../appendices/keyboard_shortcuts_pdf.rst:1
+msgid "Lookup"
+msgstr "Consulter le site"
+
+#: ../../appendices/keyboard_shortcuts_pdf.rst:1
+msgid "Ctrl+L"
+msgstr ""
+
+#: ../../appendices/keyboard_shortcuts_pdf.rst:1
+msgid "Cmd+L"
+msgstr ""
+
+#: ../../appendices/keyboard_shortcuts_pdf.rst:1
+msgid "Scan"
+msgstr "Scanner"
+
+#: ../../appendices/keyboard_shortcuts_pdf.rst:1
+msgid "Ctrl+Y"
+msgstr ""
+
+#: ../../appendices/keyboard_shortcuts_pdf.rst:1
+msgid "Cluster"
+msgstr "Cluster"
+
+#: ../../appendices/keyboard_shortcuts_pdf.rst:1
+msgid "Ctrl+U"
+msgstr ""
+
+#: ../../appendices/keyboard_shortcuts_pdf.rst:1
+msgid "Cmd+U"
+msgstr ""
+
+#: ../../appendices/keyboard_shortcuts_pdf.rst:1
+msgid "Lookup in browser"
+msgstr "Recherche dans le navigateur"
+
+#: ../../appendices/keyboard_shortcuts_pdf.rst:1
+msgid "Ctrl+Shift+L"
+msgstr ""
+
+#: ../../appendices/keyboard_shortcuts_pdf.rst:1
+msgid "Cmd+Shift+L"
+msgstr ""
+
+#: ../../appendices/keyboard_shortcuts_pdf.rst:1
+msgid "Search for similar tracks"
+msgstr "Rechercher des pistes similaires"
+
+#: ../../appendices/keyboard_shortcuts_pdf.rst:1
+msgid "Ctrl+T"
+msgstr ""
+
+#: ../../appendices/keyboard_shortcuts_pdf.rst:1
+msgid "Cmd+T"
+msgstr ""
+
+#: ../../appendices/keyboard_shortcuts_pdf.rst:1
+msgid "Generate AcoustID fingerprints"
+msgstr "Générer des empreintes digitales AcoustID"
+
+#: ../../appendices/keyboard_shortcuts_pdf.rst:1
+msgid "Ctrl+Shift+Y"
+msgstr ""
+
+#: ../../appendices/keyboard_shortcuts_pdf.rst:1
+msgid "Cmd+Shift+Y"
+msgstr ""
+
+#: ../../appendices/keyboard_shortcuts_pdf.rst:1
+msgid "Tags from file names"
+msgstr "Balises à partir des noms de fichiers"
+
+#: ../../appendices/keyboard_shortcuts_pdf.rst:1
+msgid "Ctrl+Shift+T"
+msgstr ""
+
+#: ../../appendices/keyboard_shortcuts_pdf.rst:1
+msgid "Cmd+Shift+T"
+msgstr ""
+
+#: ../../appendices/keyboard_shortcuts_pdf.rst:1
+#: ../../appendices/keyboard_shortcuts_pdf.rst:65
+msgid "Help"
+msgstr "Aide"
+
+#: ../../appendices/keyboard_shortcuts_pdf.rst:1
+msgid "F1"
+msgstr ""
+
+#: ../../appendices/keyboard_shortcuts_pdf.rst:1
+msgid "Ctrl+?"
+msgstr ""
+
+#: ../../appendices/keyboard_shortcuts_pdf.rst:1
+msgid "View activity history"
+msgstr "Afficher l'historique des activités"
+
+#: ../../appendices/keyboard_shortcuts_pdf.rst:1
+msgid "Ctrl+H"
+msgstr ""
+
+#: ../../appendices/keyboard_shortcuts_pdf.rst:1
+msgid "Cmd+Shift+H"
+msgstr ""
+
+#: ../../appendices/keyboard_shortcuts_pdf.rst:1
+msgid "View error/debug log"
+msgstr "Afficher le journal d'erreur/débogage"
+
+#: ../../appendices/keyboard_shortcuts_pdf.rst:1
+msgid "Ctrl+G"
+msgstr ""
+
+#: ../../appendices/keyboard_shortcuts_pdf.rst:1
+msgid "Cmd+G"
+msgstr ""
+
+#: ../../appendices/keyboard_shortcuts_pdf.rst:76
+msgid "Metadata view"
+msgstr "Vue des métadonnées"
+
+#: ../../appendices/keyboard_shortcuts_pdf.rst:1
+msgid "Add new tag"
+msgstr "Ajouter un nouveau tag"
+
+#: ../../appendices/keyboard_shortcuts_pdf.rst:1
+msgid "Alt+Shift+A"
+msgstr ""
+
+#: ../../appendices/keyboard_shortcuts_pdf.rst:1
+msgid "Edit selected tag"
+msgstr "Modifier la balise sélectionnée"
+
+#: ../../appendices/keyboard_shortcuts_pdf.rst:1
+msgid "Alt+Shift+E"
+msgstr ""
+
+#: ../../appendices/keyboard_shortcuts_pdf.rst:1
+msgid "Remove selected tag"
+msgstr "Supprimer la balise sélectionnée"
+
+#: ../../appendices/keyboard_shortcuts_pdf.rst:1
+msgid "Alt+Shift+R |br| Del"
+msgstr ""
+
+#: ../../appendices/keyboard_shortcuts_pdf.rst:1
+msgid "Alt+Shift+R |br| Del |br| Cmd+BackDel"
+msgstr ""
+
+#: ../../appendices/keyboard_shortcuts_pdf.rst:1
+msgid "Copy selected tag value"
+msgstr "Copier la valeur de la balise sélectionnée"
+
+#: ../../appendices/keyboard_shortcuts_pdf.rst:1
+msgid "Ctrl+C"
+msgstr ""
+
+#: ../../appendices/keyboard_shortcuts_pdf.rst:1
+msgid "Cmd+C"
+msgstr ""
+
+#: ../../appendices/keyboard_shortcuts_pdf.rst:1
+msgid "Paste to selected tag value"
+msgstr "Coller à la valeur de la balise sélectionnée"
+
+#: ../../appendices/keyboard_shortcuts_pdf.rst:89
+msgid "Other"
+msgstr "Autre"
+
+#: ../../appendices/keyboard_shortcuts_pdf.rst:1
+msgid "Focus search"
+msgstr "Recherche ciblée"
+
+#: ../../appendices/keyboard_shortcuts_pdf.rst:1
+msgid "Ctrl+F"
+msgstr ""
+
+#: ../../appendices/keyboard_shortcuts_pdf.rst:1
+msgid "Cmd+F"
+msgstr ""
+
+#: ../../appendices/keyboard_shortcuts_pdf.rst:1
+msgid "Remove selected item"
+msgstr "Supprimer l'élément sélectionné"
+
+#: ../../appendices/keyboard_shortcuts_pdf.rst:1
+msgid "Del"
+msgstr ""
+
+#: ../../appendices/keyboard_shortcuts_pdf.rst:1
+msgid "Del |br| Cmd+BackDel"
+msgstr ""
+
+#: ../../appendices/keyboard_shortcuts_pdf.rst:100
+msgid "Script editor"
+msgstr "Éditeur de script"
+
+#: ../../appendices/keyboard_shortcuts_pdf.rst:1
+msgid "Show auto completion"
+msgstr "Afficher la complétion automatique"
+
+#: ../../appendices/keyboard_shortcuts_pdf.rst:1
+msgid "Ctrl+Space"
+msgstr ""
+
+#: ../../appendices/keyboard_shortcuts_pdf.rst:1
+msgid "^+Space"
+msgstr ""
+
+#: ../../appendices/keyboard_shortcuts_pdf.rst:1
+msgid "Use selected completion"
+msgstr "Utiliser l'achèvement sélectionné"
+
+#: ../../appendices/keyboard_shortcuts_pdf.rst:1
+msgid "Tab |br| Return"
+msgstr ""
+
+#: ../../appendices/keyboard_shortcuts_pdf.rst:1
+msgid "Hide completions"
+msgstr "Cacher les achèvements"
+
+#: ../../appendices/keyboard_shortcuts_pdf.rst:1
+msgid "Esc"
+msgstr ""

--- a/appendices/keyboard_shortcuts_pdf.rst
+++ b/appendices/keyboard_shortcuts_pdf.rst
@@ -1,0 +1,113 @@
+.. MusicBrainz Picard Documentation Project
+
+.. |br| raw:: latex
+
+   \newline
+
+Appendix D: :index:`Keyboard Shortcuts <user interface; keyboard shortcuts>`
+============================================================================
+
+Main window
+-----------
+
+File
+++++++
+
+.. csv-table::
+   :width: 100%
+   :widths: 50 25 25
+   :header: "**Action**", "**Windows / Linux**", "**macOS**"
+
+   "Add folder", "Ctrl+E", "Cmd+E"
+   "Add files", "Ctrl+O", "Cmd+O"
+   "Save selected files", "Ctrl+S", "Cmd+S"
+   "Quit Picard", "Ctrl+Q", "Cmd+Q"
+
+Edit
+++++++
+
+.. csv-table::
+   :width: 100%
+   :widths: 50 25 25
+   :header: "**Action**", "**Windows / Linux**", "**macOS**"
+
+   "Cut selected files", "Ctrl+X", "Cmd+X"
+   "Paste selected files", "Ctrl+V", "Cmd+V"
+   "Show info for selected item", "Ctrl+I", "Cmd+I"
+
+View
+++++++++
+.. csv-table::
+   :width: 100%
+   :widths: 50 25 25
+   :header: "**Action**", "**Windows / Linux**", "**macOS**"
+
+   "Toggle file browser", "Ctrl+B", "Cmd+B"
+
+Tools
++++++++++++
+.. csv-table::
+   :width: 100%
+   :widths: 50 25 25
+   :header: "**Action**", "**Windows / Linux**", "**macOS**"
+
+   "Refresh", "Ctrl+R", "Cmd+R"
+   "Lookup CD", "Ctrl+K", "Cmd+K"
+   "Lookup", "Ctrl+L", "Cmd+L"
+   "Scan", "Ctrl+Y", "Ctrl+Y"
+   "Cluster", "Ctrl+U", "Cmd+U"
+   "Lookup in browser", "Ctrl+Shift+L", "Cmd+Shift+L"
+   "Search for similar tracks", "Ctrl+T", "Cmd+T"
+   "Generate AcoustID fingerprints", "Ctrl+Shift+Y", "Cmd+Shift+Y"
+   "Tags from file names", "Ctrl+Shift+T", "Cmd+Shift+T"
+
+Help
++++++++++
+.. csv-table::
+   :width: 100%
+   :widths: 50 25 25
+   :header: "**Action**", "**Windows / Linux**", "**macOS**"
+
+   "Help", "F1", "Ctrl+?"
+   "View activity history", "Ctrl+H", "Cmd+Shift+H"
+   "View error/debug log", "Ctrl+G", "Cmd+G"
+
+Metadata view
++++++++++++++++
+.. csv-table::
+   :width: 100%
+   :widths: 50 25 25
+   :header: "**Action**", "**Windows / Linux**", "**macOS**"
+
+   "Add new tag", "Alt+Shift+A", "Alt+Shift+A"
+   "Edit selected tag", "Alt+Shift+E", "Alt+Shift+E"
+   "Remove selected tag", "Alt+Shift+R |br| Del", "Alt+Shift+R |br| Del |br| Cmd+BackDel"
+   "Copy selected tag value", "Ctrl+C", "Cmd+C"
+   "Paste to selected tag value", "Ctrl+V", "Cmd+V"
+
+Other
+++++++++++++++
+.. csv-table::
+   :width: 100%
+   :widths: 50 25 25
+   :header: "**Action**", "**Windows / Linux**", "**macOS**"
+
+   "Focus search", "Ctrl+F", "Cmd+F"
+   "Remove selected item", "Del", "Del |br| Cmd+BackDel"
+
+
+Script editor
+-------------
+
+.. csv-table::
+   :width: 100%
+   :widths: 50 25 25
+   :header: "**Action**", "**Windows / Linux**", "**macOS**"
+
+   "Show auto completion", "Ctrl+Space", "^+Space"
+   "Use selected completion", "Tab |br| Return", "Tab |br| Return"
+   "Hide completions", "Esc", "Esc"
+
+.. raw:: latex
+
+   \clearpage

--- a/appendices/pdf_appendices.rst
+++ b/appendices/pdf_appendices.rst
@@ -8,3 +8,4 @@ Appendices
    plugins_api
    tag_mapping
    command_line
+   keyboard_shortcuts_pdf


### PR DESCRIPTION
<!--
    Thank-you for submitting a pull request. Your effort and input is appreciated.

    Please use this template to help us review your change. Not everything is
    required for every change, so please feel free to omit any sections that
    are not relevant to your change.

    Also, please ensure that you've reviewed the guidelines in CONTRIBUTING.md.
-->

### Summary

This is a…

- [ ] Correction
- [x] Addition
- [ ] Restructuring
- [ ] Minor / simple change (like a typo)
- [ ] Other

### Reason for the Change

Add keyboard shortcut information to the PDF version of the Picard User Guide, and include French language translations.

### Description of the Change

Add `*.rst` file to build for PDF output.  Replace macOS special symbols with key text for the PDF output because of build failures due to unknown UTF-8 characters.  Add French translation files.

### Additional Action Required

Continue to look into Sphinx problems building the PDF files with the macOS UTF-8 special symbols.
