### PR TITLE
Render keyboard shortcuts with kbd role

### DIFF
--- a/_locale/fr/LC_MESSAGES/appendices/keyboard_shortcuts.po
+++ b/_locale/fr/LC_MESSAGES/appendices/keyboard_shortcuts.po
@@ -8,17 +8,16 @@ msgid ""
 msgstr ""
 "Project-Id-Version: MusicBrainz Picard v2.6\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-04-08 15:23-0600\n"
+"POT-Creation-Date: 2021-05-01 10:16-0600\n"
 "PO-Revision-Date: 2021-04-08 16:01-0600\n"
 "Last-Translator: Bob Swift <bswift@rsds.ca>\n"
 "Language: fr\n"
 "Language-Team: \n"
-"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+"Plural-Forms: nplurals=2; plural=(n > 1)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: Babel 2.8.0\n"
-"X-Generator: Poedit 2.4.2\n"
 
 #: ../../appendices/keyboard_shortcuts.rst:14
 msgid ""
@@ -53,11 +52,11 @@ msgid "Add folder"
 msgstr "Ajouter un dossier"
 
 #: ../../appendices/keyboard_shortcuts.rst:1
-msgid "Ctrl+E"
+msgid ":kbd:`Ctrl+E`"
 msgstr ""
 
 #: ../../appendices/keyboard_shortcuts.rst:1
-msgid "⌘+E"
+msgid ":kbd:`⌘+E`"
 msgstr ""
 
 #: ../../appendices/keyboard_shortcuts.rst:1
@@ -65,11 +64,11 @@ msgid "Add files"
 msgstr "Ajouter des fichiers"
 
 #: ../../appendices/keyboard_shortcuts.rst:1
-msgid "Ctrl+O"
+msgid ":kbd:`Ctrl+O`"
 msgstr ""
 
 #: ../../appendices/keyboard_shortcuts.rst:1
-msgid "⌘+O"
+msgid ":kbd:`⌘+O`"
 msgstr ""
 
 #: ../../appendices/keyboard_shortcuts.rst:1
@@ -77,11 +76,11 @@ msgid "Save selected files"
 msgstr "Sauvegarder les fichiers sélectionnés"
 
 #: ../../appendices/keyboard_shortcuts.rst:1
-msgid "Ctrl+S"
+msgid ":kbd:`Ctrl+S`"
 msgstr ""
 
 #: ../../appendices/keyboard_shortcuts.rst:1
-msgid "⌘+S"
+msgid ":kbd:`⌘+S`"
 msgstr ""
 
 #: ../../appendices/keyboard_shortcuts.rst:1
@@ -89,11 +88,11 @@ msgid "Quit Picard"
 msgstr "Quitter Picard"
 
 #: ../../appendices/keyboard_shortcuts.rst:1
-msgid "Ctrl+Q"
+msgid ":kbd:`Ctrl+Q`"
 msgstr ""
 
 #: ../../appendices/keyboard_shortcuts.rst:1
-msgid "⌘+Q"
+msgid ":kbd:`⌘+Q`"
 msgstr ""
 
 #: ../../appendices/keyboard_shortcuts.rst:33
@@ -105,11 +104,11 @@ msgid "Cut selected files"
 msgstr "Couper les fichiers sélectionnés"
 
 #: ../../appendices/keyboard_shortcuts.rst:1
-msgid "Ctrl+X"
+msgid ":kbd:`Ctrl+X`"
 msgstr ""
 
 #: ../../appendices/keyboard_shortcuts.rst:1
-msgid "⌘+X"
+msgid ":kbd:`⌘+X`"
 msgstr ""
 
 #: ../../appendices/keyboard_shortcuts.rst:1
@@ -117,11 +116,11 @@ msgid "Paste selected files"
 msgstr "Coller les fichiers sélectionnés"
 
 #: ../../appendices/keyboard_shortcuts.rst:1
-msgid "Ctrl+V"
+msgid ":kbd:`Ctrl+V`"
 msgstr ""
 
 #: ../../appendices/keyboard_shortcuts.rst:1
-msgid "⌘+V"
+msgid ":kbd:`⌘+V`"
 msgstr ""
 
 #: ../../appendices/keyboard_shortcuts.rst:1
@@ -129,11 +128,11 @@ msgid "Show info for selected item"
 msgstr "Afficher les informations sur l'élément sélectionné"
 
 #: ../../appendices/keyboard_shortcuts.rst:1
-msgid "Ctrl+I"
+msgid ":kbd:`Ctrl+I`"
 msgstr ""
 
 #: ../../appendices/keyboard_shortcuts.rst:1
-msgid "⌘+I"
+msgid ":kbd:`⌘+I`"
 msgstr ""
 
 #: ../../appendices/keyboard_shortcuts.rst:45
@@ -145,11 +144,11 @@ msgid "Toggle file browser"
 msgstr "Basculer le navigateur de fichiers"
 
 #: ../../appendices/keyboard_shortcuts.rst:1
-msgid "Ctrl+B"
+msgid ":kbd:`Ctrl+B`"
 msgstr ""
 
 #: ../../appendices/keyboard_shortcuts.rst:1
-msgid "⌘+B"
+msgid ":kbd:`⌘+B`"
 msgstr ""
 
 #: ../../appendices/keyboard_shortcuts.rst:1
@@ -157,14 +156,14 @@ msgid "Toggle metadata view"
 msgstr "Basculer l'affichage des métadonnées"
 
 #: ../../appendices/keyboard_shortcuts.rst:1
-msgid "Ctrl+Shift+M"
+msgid ":kbd:`Ctrl+Shift+M`"
 msgstr ""
 
 #: ../../appendices/keyboard_shortcuts.rst:1
-msgid "⌘+⇧+M"
+msgid ":kbd:`⌘+⇧+M`"
 msgstr ""
 
-#: ../../appendices/keyboard_shortcuts.rst:55
+#: ../../appendices/keyboard_shortcuts.rst:56
 msgid "Tools"
 msgstr "Outils"
 
@@ -173,11 +172,11 @@ msgid "Refresh"
 msgstr "Rafraîchir"
 
 #: ../../appendices/keyboard_shortcuts.rst:1
-msgid "Ctrl+R"
+msgid ":kbd:`Ctrl+R`"
 msgstr ""
 
 #: ../../appendices/keyboard_shortcuts.rst:1
-msgid "⌘+R"
+msgid ":kbd:`⌘+R`"
 msgstr ""
 
 #: ../../appendices/keyboard_shortcuts.rst:1
@@ -185,11 +184,11 @@ msgid "Lookup CD"
 msgstr "CD de recherche"
 
 #: ../../appendices/keyboard_shortcuts.rst:1
-msgid "Ctrl+K"
+msgid ":kbd:`Ctrl+K`"
 msgstr ""
 
 #: ../../appendices/keyboard_shortcuts.rst:1
-msgid "⌘+K"
+msgid ":kbd:`⌘+K`"
 msgstr ""
 
 #: ../../appendices/keyboard_shortcuts.rst:1
@@ -197,11 +196,11 @@ msgid "Lookup"
 msgstr "Consulter le site"
 
 #: ../../appendices/keyboard_shortcuts.rst:1
-msgid "Ctrl+L"
+msgid ":kbd:`Ctrl+L`"
 msgstr ""
 
 #: ../../appendices/keyboard_shortcuts.rst:1
-msgid "⌘+L"
+msgid ":kbd:`⌘+L`"
 msgstr ""
 
 #: ../../appendices/keyboard_shortcuts.rst:1
@@ -209,11 +208,11 @@ msgid "Scan"
 msgstr "Scanner"
 
 #: ../../appendices/keyboard_shortcuts.rst:1
-msgid "Ctrl+Y"
+msgid ":kbd:`Ctrl+Y`"
 msgstr ""
 
 #: ../../appendices/keyboard_shortcuts.rst:1
-msgid "⌘+Y"
+msgid ":kbd:`⌘+Y`"
 msgstr ""
 
 #: ../../appendices/keyboard_shortcuts.rst:1
@@ -221,11 +220,11 @@ msgid "Cluster"
 msgstr "Cluster"
 
 #: ../../appendices/keyboard_shortcuts.rst:1
-msgid "Ctrl+U"
+msgid ":kbd:`Ctrl+U`"
 msgstr ""
 
 #: ../../appendices/keyboard_shortcuts.rst:1
-msgid "⌘+U"
+msgid ":kbd:`⌘+U`"
 msgstr ""
 
 #: ../../appendices/keyboard_shortcuts.rst:1
@@ -233,11 +232,11 @@ msgid "Lookup in browser"
 msgstr "Recherche dans le navigateur"
 
 #: ../../appendices/keyboard_shortcuts.rst:1
-msgid "Ctrl+Shift+L"
+msgid ":kbd:`Ctrl+Shift+L`"
 msgstr ""
 
 #: ../../appendices/keyboard_shortcuts.rst:1
-msgid "⌘+⇧+L"
+msgid ":kbd:`⌘+⇧+L`"
 msgstr ""
 
 #: ../../appendices/keyboard_shortcuts.rst:1
@@ -245,11 +244,11 @@ msgid "Search for similar tracks"
 msgstr "Rechercher des pistes similaires"
 
 #: ../../appendices/keyboard_shortcuts.rst:1
-msgid "Ctrl+T"
+msgid ":kbd:`Ctrl+T`"
 msgstr ""
 
 #: ../../appendices/keyboard_shortcuts.rst:1
-msgid "⌘+T"
+msgid ":kbd:`⌘+T`"
 msgstr ""
 
 #: ../../appendices/keyboard_shortcuts.rst:1
@@ -257,11 +256,11 @@ msgid "Generate AcoustID fingerprints"
 msgstr "Générer des empreintes digitales AcoustID"
 
 #: ../../appendices/keyboard_shortcuts.rst:1
-msgid "Ctrl+Shift+Y"
+msgid ":kbd:`Ctrl+Shift+Y`"
 msgstr ""
 
 #: ../../appendices/keyboard_shortcuts.rst:1
-msgid "⌘+⇧+Y"
+msgid ":kbd:`⌘+⇧+Y`"
 msgstr ""
 
 #: ../../appendices/keyboard_shortcuts.rst:1
@@ -269,24 +268,24 @@ msgid "Tags from file names"
 msgstr "Balises à partir des noms de fichiers"
 
 #: ../../appendices/keyboard_shortcuts.rst:1
-msgid "Ctrl+Shift+T"
+msgid ":kbd:`Ctrl+Shift+T`"
 msgstr ""
 
 #: ../../appendices/keyboard_shortcuts.rst:1
-msgid "⌘+⇧+T"
+msgid ":kbd:`⌘+⇧+T`"
 msgstr ""
 
 #: ../../appendices/keyboard_shortcuts.rst:1
-#: ../../appendices/keyboard_shortcuts.rst:72
+#: ../../appendices/keyboard_shortcuts.rst:74
 msgid "Help"
 msgstr "Aide"
 
 #: ../../appendices/keyboard_shortcuts.rst:1
-msgid "F1"
+msgid ":kbd:`F1`"
 msgstr ""
 
 #: ../../appendices/keyboard_shortcuts.rst:1
-msgid "⌘+?"
+msgid ":kbd:`⌘+?`"
 msgstr ""
 
 #: ../../appendices/keyboard_shortcuts.rst:1
@@ -294,11 +293,11 @@ msgid "View activity history"
 msgstr "Afficher l'historique des activités"
 
 #: ../../appendices/keyboard_shortcuts.rst:1
-msgid "Ctrl+H"
+msgid ":kbd:`Ctrl+H`"
 msgstr ""
 
 #: ../../appendices/keyboard_shortcuts.rst:1
-msgid "⌘+⇧+H"
+msgid ":kbd:`⌘+⇧+H`"
 msgstr ""
 
 #: ../../appendices/keyboard_shortcuts.rst:1
@@ -306,14 +305,14 @@ msgid "View error/debug log"
 msgstr "Afficher le journal d'erreur/débogage"
 
 #: ../../appendices/keyboard_shortcuts.rst:1
-msgid "Ctrl+G"
+msgid ":kbd:`Ctrl+G`"
 msgstr ""
 
 #: ../../appendices/keyboard_shortcuts.rst:1
-msgid "⌘+G"
+msgid ":kbd:`⌘+G`"
 msgstr ""
 
-#: ../../appendices/keyboard_shortcuts.rst:83
+#: ../../appendices/keyboard_shortcuts.rst:86
 msgid "Metadata view"
 msgstr "Vue des métadonnées"
 
@@ -322,11 +321,11 @@ msgid "Add new tag"
 msgstr "Ajouter un nouveau tag"
 
 #: ../../appendices/keyboard_shortcuts.rst:1
-msgid "Alt+Shift+A"
+msgid ":kbd:`Alt+Shift+A`"
 msgstr ""
 
 #: ../../appendices/keyboard_shortcuts.rst:1
-msgid "⌥+⇧+A"
+msgid ":kbd:`⌥+⇧+A`"
 msgstr ""
 
 #: ../../appendices/keyboard_shortcuts.rst:1
@@ -334,11 +333,11 @@ msgid "Edit selected tag"
 msgstr "Modifier la balise sélectionnée"
 
 #: ../../appendices/keyboard_shortcuts.rst:1
-msgid "Alt+Shift+E"
+msgid ":kbd:`Alt+Shift+E`"
 msgstr ""
 
 #: ../../appendices/keyboard_shortcuts.rst:1
-msgid "⌥+⇧+E"
+msgid ":kbd:`⌥+⇧+E`"
 msgstr ""
 
 #: ../../appendices/keyboard_shortcuts.rst:1
@@ -346,11 +345,11 @@ msgid "Remove selected tag"
 msgstr "Supprimer la balise sélectionnée"
 
 #: ../../appendices/keyboard_shortcuts.rst:1
-msgid "Alt+Shift+R |br| |nl| Del"
+msgid ":kbd:`Alt+Shift+R` |br| |nl| :kbd:`Del`"
 msgstr ""
 
 #: ../../appendices/keyboard_shortcuts.rst:1
-msgid "⌥+⇧+R |br| |nl| Del |br| |nl| ⌘+⌫"
+msgid ":kbd:`⌥+⇧+R` |br| |nl| :kbd:`Del` |br| |nl| :kbd:`⌘+⌫`"
 msgstr ""
 
 #: ../../appendices/keyboard_shortcuts.rst:1
@@ -358,18 +357,18 @@ msgid "Copy selected tag value"
 msgstr "Copier la valeur de la balise sélectionnée"
 
 #: ../../appendices/keyboard_shortcuts.rst:1
-msgid "Ctrl+C"
+msgid ":kbd:`Ctrl+C`"
 msgstr ""
 
 #: ../../appendices/keyboard_shortcuts.rst:1
-msgid "⌘+C"
+msgid ":kbd:`⌘+C`"
 msgstr ""
 
 #: ../../appendices/keyboard_shortcuts.rst:1
 msgid "Paste to selected tag value"
 msgstr "Coller à la valeur de la balise sélectionnée"
 
-#: ../../appendices/keyboard_shortcuts.rst:96
+#: ../../appendices/keyboard_shortcuts.rst:100
 msgid "Other"
 msgstr "Autre"
 
@@ -378,11 +377,11 @@ msgid "Focus search"
 msgstr "Recherche ciblée"
 
 #: ../../appendices/keyboard_shortcuts.rst:1
-msgid "Ctrl+F"
+msgid ":kbd:`Ctrl+F`"
 msgstr ""
 
 #: ../../appendices/keyboard_shortcuts.rst:1
-msgid "⌘+F"
+msgid ":kbd:`⌘+F`"
 msgstr ""
 
 #: ../../appendices/keyboard_shortcuts.rst:1
@@ -390,14 +389,14 @@ msgid "Remove selected item"
 msgstr "Supprimer l'élément sélectionné"
 
 #: ../../appendices/keyboard_shortcuts.rst:1
-msgid "Del"
+msgid ":kbd:`Del`"
 msgstr ""
 
 #: ../../appendices/keyboard_shortcuts.rst:1
-msgid "Del |br| |nl| ⌘+⌫"
+msgid ":kbd:`Del` |br| |nl| :kbd:`⌘+⌫`"
 msgstr ""
 
-#: ../../appendices/keyboard_shortcuts.rst:107
+#: ../../appendices/keyboard_shortcuts.rst:111
 msgid "Script editor"
 msgstr "Éditeur de script"
 
@@ -406,11 +405,11 @@ msgid "Show auto completion"
 msgstr "Afficher la complétion automatique"
 
 #: ../../appendices/keyboard_shortcuts.rst:1
-msgid "Ctrl+Space"
+msgid ":kbd:`Ctrl+Space`"
 msgstr ""
 
 #: ../../appendices/keyboard_shortcuts.rst:1
-msgid "⌃+Space"
+msgid ":kbd:`⌃+Space`"
 msgstr ""
 
 #: ../../appendices/keyboard_shortcuts.rst:1
@@ -418,7 +417,7 @@ msgid "Use selected completion"
 msgstr "Utiliser l'achèvement sélectionné"
 
 #: ../../appendices/keyboard_shortcuts.rst:1
-msgid "Tab |br| |nl| Return"
+msgid ":kbd:`Tab` |br| |nl| :kbd:`Return`"
 msgstr ""
 
 #: ../../appendices/keyboard_shortcuts.rst:1
@@ -426,7 +425,7 @@ msgid "Hide completions"
 msgstr "Cacher les achèvements"
 
 #: ../../appendices/keyboard_shortcuts.rst:1
-msgid "Esc"
+msgid ":kbd:`Esc`"
 msgstr ""
 
 #~ msgid "macOS"
@@ -446,3 +445,178 @@ msgstr ""
 
 #~ msgid "**Other**"
 #~ msgstr "**Autre**"
+
+#~ msgid "Ctrl+E"
+#~ msgstr ""
+
+#~ msgid "⌘+E"
+#~ msgstr ""
+
+#~ msgid "Ctrl+O"
+#~ msgstr ""
+
+#~ msgid "⌘+O"
+#~ msgstr ""
+
+#~ msgid "Ctrl+S"
+#~ msgstr ""
+
+#~ msgid "⌘+S"
+#~ msgstr ""
+
+#~ msgid "Ctrl+Q"
+#~ msgstr ""
+
+#~ msgid "⌘+Q"
+#~ msgstr ""
+
+#~ msgid "Ctrl+X"
+#~ msgstr ""
+
+#~ msgid "⌘+X"
+#~ msgstr ""
+
+#~ msgid "Ctrl+V"
+#~ msgstr ""
+
+#~ msgid "⌘+V"
+#~ msgstr ""
+
+#~ msgid "Ctrl+I"
+#~ msgstr ""
+
+#~ msgid "⌘+I"
+#~ msgstr ""
+
+#~ msgid "Ctrl+B"
+#~ msgstr ""
+
+#~ msgid "⌘+B"
+#~ msgstr ""
+
+#~ msgid "Ctrl+Shift+M"
+#~ msgstr ""
+
+#~ msgid "⌘+⇧+M"
+#~ msgstr ""
+
+#~ msgid "Ctrl+R"
+#~ msgstr ""
+
+#~ msgid "⌘+R"
+#~ msgstr ""
+
+#~ msgid "Ctrl+K"
+#~ msgstr ""
+
+#~ msgid "⌘+K"
+#~ msgstr ""
+
+#~ msgid "Ctrl+L"
+#~ msgstr ""
+
+#~ msgid "⌘+L"
+#~ msgstr ""
+
+#~ msgid "Ctrl+Y"
+#~ msgstr ""
+
+#~ msgid "⌘+Y"
+#~ msgstr ""
+
+#~ msgid "Ctrl+U"
+#~ msgstr ""
+
+#~ msgid "⌘+U"
+#~ msgstr ""
+
+#~ msgid "Ctrl+Shift+L"
+#~ msgstr ""
+
+#~ msgid "⌘+⇧+L"
+#~ msgstr ""
+
+#~ msgid "Ctrl+T"
+#~ msgstr ""
+
+#~ msgid "⌘+T"
+#~ msgstr ""
+
+#~ msgid "Ctrl+Shift+Y"
+#~ msgstr ""
+
+#~ msgid "⌘+⇧+Y"
+#~ msgstr ""
+
+#~ msgid "Ctrl+Shift+T"
+#~ msgstr ""
+
+#~ msgid "⌘+⇧+T"
+#~ msgstr ""
+
+#~ msgid "F1"
+#~ msgstr ""
+
+#~ msgid "⌘+?"
+#~ msgstr ""
+
+#~ msgid "Ctrl+H"
+#~ msgstr ""
+
+#~ msgid "⌘+⇧+H"
+#~ msgstr ""
+
+#~ msgid "Ctrl+G"
+#~ msgstr ""
+
+#~ msgid "⌘+G"
+#~ msgstr ""
+
+#~ msgid "Alt+Shift+A"
+#~ msgstr ""
+
+#~ msgid "⌥+⇧+A"
+#~ msgstr ""
+
+#~ msgid "Alt+Shift+E"
+#~ msgstr ""
+
+#~ msgid "⌥+⇧+E"
+#~ msgstr ""
+
+#~ msgid "Alt+Shift+R |br| |nl| Del"
+#~ msgstr ""
+
+#~ msgid "⌥+⇧+R |br| |nl| Del |br| |nl| ⌘+⌫"
+#~ msgstr ""
+
+#~ msgid "Ctrl+C"
+#~ msgstr ""
+
+#~ msgid "⌘+C"
+#~ msgstr ""
+
+#~ msgid "Ctrl+F"
+#~ msgstr ""
+
+#~ msgid "⌘+F"
+#~ msgstr ""
+
+#~ msgid "Del"
+#~ msgstr ""
+
+#~ msgid "Del |br| |nl| ⌘+⌫"
+#~ msgstr ""
+
+#~ msgid "Ctrl+Space"
+#~ msgstr ""
+
+#~ msgid "⌃+Space"
+#~ msgstr ""
+
+#~ msgid "Tab |br| |nl| Return"
+#~ msgstr ""
+
+#~ msgid "Esc"
+#~ msgstr ""
+

--- a/_static/css/extra.css
+++ b/_static/css/extra.css
@@ -55,3 +55,23 @@ table.colwidths-given.docutils.align-default tbody tr td {
     width: auto;
     overflow-y: auto;
 }
+
+/* adds formatting for keyboard shortcuts */
+
+kbd.compound {
+    white-space: nowrap;
+}
+
+kbd:not(.compound) {
+    display: inline-block;
+    background-color: #f7f7f7;
+    padding: .15em .4em;
+    margin-left: 1px;
+    margin-right: 1px;
+    margin-bottom: .4em;
+    border: 1px solid #bbb;
+    border-radius: 6px;
+    box-shadow: inset 0 -1px 0 #ddd;
+    line-height: 1em;
+    font-size: .9em;
+}

--- a/appendices/keyboard_shortcuts.rst
+++ b/appendices/keyboard_shortcuts.rst
@@ -19,101 +19,216 @@ Main window
 File
 ++++++
 
-.. csv-table::
-   :width: 100%
-   :widths: 50 25 25
-   :header: "**Action**", "**Windows / Linux**", "**macOS**"
+.. only:: html
 
-   "Add folder", :kbd:`Ctrl+E`, :kbd:`⌘+E`
-   "Add files", :kbd:`Ctrl+O`, :kbd:`⌘+O`
-   "Save selected files", :kbd:`Ctrl+S`, :kbd:`⌘+S`
-   "Quit Picard", :kbd:`Ctrl+Q`, :kbd:`⌘+Q`
+   .. csv-table::
+      :width: 100%
+      :widths: 50 25 25
+      :header: "**Action**", "**Windows / Linux**", "**macOS**"
+
+      "Add folder", :kbd:`Ctrl+E`, :kbd:`⌘+E`
+      "Add files", :kbd:`Ctrl+O`, :kbd:`⌘+O`
+      "Save selected files", :kbd:`Ctrl+S`, :kbd:`⌘+S`
+      "Quit Picard", :kbd:`Ctrl+Q`, :kbd:`⌘+Q`
+
+.. only:: latex
+
+   .. csv-table::
+      :width: 100%
+      :widths: 50 25 25
+      :header: "**Action**", "**Windows / Linux**", "**macOS**"
+
+      "Add folder", "Ctrl+E", "⌘+E"
+      "Add files", "Ctrl+O", "⌘+O"
+      "Save selected files", "Ctrl+S", "⌘+S"
+      "Quit Picard", "Ctrl+Q", "⌘+Q"
 
 Edit
 ++++++
 
-.. csv-table::
-   :width: 100%
-   :widths: 50 25 25
-   :header: "**Action**", "**Windows / Linux**", "**macOS**"
+.. only:: html
 
-   "Cut selected files", :kbd:`Ctrl+X`, :kbd:`⌘+X`
-   "Paste selected files", :kbd:`Ctrl+V`, :kbd:`⌘+V`
-   "Show info for selected item", :kbd:`Ctrl+I`, :kbd:`⌘+I`
+   .. csv-table::
+      :width: 100%
+      :widths: 50 25 25
+      :header: "**Action**", "**Windows / Linux**", "**macOS**"
+
+      "Cut selected files", :kbd:`Ctrl+X`, :kbd:`⌘+X`
+      "Paste selected files", :kbd:`Ctrl+V`, :kbd:`⌘+V`
+      "Show info for selected item", :kbd:`Ctrl+I`, :kbd:`⌘+I`
+
+.. only:: latex
+
+   .. csv-table::
+      :width: 100%
+      :widths: 50 25 25
+      :header: "**Action**", "**Windows / Linux**", "**macOS**"
+
+      "Cut selected files", "Ctrl+X", "⌘+X"
+      "Paste selected files", "Ctrl+V", "⌘+V"
+      "Show info for selected item", "Ctrl+I", "⌘+I"
 
 View
 ++++++++
-.. csv-table::
-   :width: 100%
-   :widths: 50 25 25
-   :header: "**Action**", "**Windows / Linux**", "**macOS**"
 
-   "Toggle file browser", :kbd:`Ctrl+B`, :kbd:`⌘+B`
-   "Toggle metadata view", :kbd:`Ctrl+Shift+M`, :kbd:`⌘+⇧+M`
+.. only:: html
+
+   .. csv-table::
+      :width: 100%
+      :widths: 50 25 25
+      :header: "**Action**", "**Windows / Linux**", "**macOS**"
+
+      "Toggle file browser", :kbd:`Ctrl+B`, :kbd:`⌘+B`
+      "Toggle metadata view", :kbd:`Ctrl+Shift+M`, :kbd:`⌘+⇧+M`
+
+.. only:: latex
+
+   .. csv-table::
+      :width: 100%
+      :widths: 50 25 25
+      :header: "**Action**", "**Windows / Linux**", "**macOS**"
+
+      "Toggle file browser", "Ctrl+B", "⌘+B"
+      "Toggle metadata view", "Ctrl+Shift+M", "⌘+⇧+M"
 
 Tools
 +++++++++++
-.. csv-table::
-   :width: 100%
-   :widths: 50 25 25
-   :header: "**Action**", "**Windows / Linux**", "**macOS**"
 
-   "Refresh", :kbd:`Ctrl+R`, :kbd:`⌘+R`
-   "Lookup CD", :kbd:`Ctrl+K`, :kbd:`⌘+K`
-   "Lookup", :kbd:`Ctrl+L`, :kbd:`⌘+L`
-   "Scan", :kbd:`Ctrl+Y`, :kbd:`⌘+Y`
-   "Cluster", :kbd:`Ctrl+U`, :kbd:`⌘+U`
-   "Lookup in browser", :kbd:`Ctrl+Shift+L`, :kbd:`⌘+⇧+L`
-   "Search for similar tracks", :kbd:`Ctrl+T`, :kbd:`⌘+T`
-   "Generate AcoustID fingerprints", :kbd:`Ctrl+Shift+Y`, :kbd:`⌘+⇧+Y`
-   "Tags from file names", :kbd:`Ctrl+Shift+T`, :kbd:`⌘+⇧+T`
+.. only:: html
+
+   .. csv-table::
+      :width: 100%
+      :widths: 50 25 25
+      :header: "**Action**", "**Windows / Linux**", "**macOS**"
+
+      "Refresh", :kbd:`Ctrl+R`, :kbd:`⌘+R`
+      "Lookup CD", :kbd:`Ctrl+K`, :kbd:`⌘+K`
+      "Lookup", :kbd:`Ctrl+L`, :kbd:`⌘+L`
+      "Scan", :kbd:`Ctrl+Y`, :kbd:`⌘+Y`
+      "Cluster", :kbd:`Ctrl+U`, :kbd:`⌘+U`
+      "Lookup in browser", :kbd:`Ctrl+Shift+L`, :kbd:`⌘+⇧+L`
+      "Search for similar tracks", :kbd:`Ctrl+T`, :kbd:`⌘+T`
+      "Generate AcoustID fingerprints", :kbd:`Ctrl+Shift+Y`, :kbd:`⌘+⇧+Y`
+      "Tags from file names", :kbd:`Ctrl+Shift+T`, :kbd:`⌘+⇧+T`
+
+.. only:: latex
+
+   .. csv-table::
+      :width: 100%
+      :widths: 50 25 25
+      :header: "**Action**", "**Windows / Linux**", "**macOS**"
+
+      "Refresh", "Ctrl+R", "⌘+R"
+      "Lookup CD", "Ctrl+K", "⌘+K"
+      "Lookup", "Ctrl+L", "⌘+L"
+      "Scan", "Ctrl+Y", "⌘+Y"
+      "Cluster", "Ctrl+U", "⌘+U"
+      "Lookup in browser", "Ctrl+Shift+L", "⌘+⇧+L"
+      "Search for similar tracks", "Ctrl+T", "⌘+T"
+      "Generate AcoustID fingerprints", "Ctrl+Shift+Y", "⌘+⇧+Y"
+      "Tags from file names", "Ctrl+Shift+T", "⌘+⇧+T"
 
 Help
 +++++++++
-.. csv-table::
-   :width: 100%
-   :widths: 50 25 25
-   :header: "**Action**", "**Windows / Linux**", "**macOS**"
 
-   "Help", :kbd:`F1`, :kbd:`⌘+?`
-   "View activity history", :kbd:`Ctrl+H`, :kbd:`⌘+⇧+H`
-   "View error/debug log", :kbd:`Ctrl+G`, :kbd:`⌘+G`
+.. only:: html
+
+   .. csv-table::
+      :width: 100%
+      :widths: 50 25 25
+      :header: "**Action**", "**Windows / Linux**", "**macOS**"
+
+      "Help", :kbd:`F1`, :kbd:`⌘+?`
+      "View activity history", :kbd:`Ctrl+H`, :kbd:`⌘+⇧+H`
+      "View error/debug log", :kbd:`Ctrl+G`, :kbd:`⌘+G`
+
+.. only:: latex
+
+   .. csv-table::
+      :width: 100%
+      :widths: 50 25 25
+      :header: "**Action**", "**Windows / Linux**", "**macOS**"
+
+      "Help", "F1", "⌘+?"
+      "View activity history", "Ctrl+H", "⌘+⇧+H"
+      "View error/debug log", "Ctrl+G", "⌘+G"
 
 Metadata view
 +++++++++++++++
-.. csv-table::
-   :width: 100%
-   :widths: 50 25 25
-   :header: "**Action**", "**Windows / Linux**", "**macOS**"
 
-   "Add new tag", :kbd:`Alt+Shift+A`, :kbd:`⌥+⇧+A`
-   "Edit selected tag", :kbd:`Alt+Shift+E`, :kbd:`⌥+⇧+E`
-   "Remove selected tag", :kbd:`Alt+Shift+R` |br| |nl| :kbd:`Del`, :kbd:`⌥+⇧+R` |br| |nl| :kbd:`Del` |br| |nl| :kbd:`⌘+⌫`
-   "Copy selected tag value", :kbd:`Ctrl+C`, :kbd:`⌘+C`
-   "Paste to selected tag value", :kbd:`Ctrl+V`, :kbd:`⌘+V`
+.. only:: html
+
+   .. csv-table::
+      :width: 100%
+      :widths: 50 25 25
+      :header: "**Action**", "**Windows / Linux**", "**macOS**"
+
+      "Add new tag", :kbd:`Alt+Shift+A`, :kbd:`⌥+⇧+A`
+      "Edit selected tag", :kbd:`Alt+Shift+E`, :kbd:`⌥+⇧+E`
+      "Remove selected tag", :kbd:`Alt+Shift+R` |br| |nl| :kbd:`Del`, :kbd:`⌥+⇧+R` |br| |nl| :kbd:`Del` |br| |nl| :kbd:`⌘+⌫`
+      "Copy selected tag value", :kbd:`Ctrl+C`, :kbd:`⌘+C`
+      "Paste to selected tag value", :kbd:`Ctrl+V`, :kbd:`⌘+V`
+
+.. only:: latex
+
+   .. csv-table::
+      :width: 100%
+      :widths: 50 25 25
+      :header: "**Action**", "**Windows / Linux**", "**macOS**"
+
+      "Add new tag", "Alt+Shift+A", "⌥+⇧+A"
+      "Edit selected tag", "Alt+Shift+E", "⌥+⇧+E"
+      "Remove selected tag", "Alt+Shift+R |br| |nl| Del", "⌥+⇧+R |br| |nl| Del |br| |nl| ⌘+⌫"
+      "Copy selected tag value", :kbd:`Ctrl+C`, :kbd:`⌘+C`
+      "Paste to selected tag value", "Ctrl+V", "⌘+V"
 
 Other
 ++++++++++++++
-.. csv-table::
-   :width: 100%
-   :widths: 50 25 25
-   :header: "**Action**", "**Windows / Linux**", "**macOS**"
 
-   "Focus search", :kbd:`Ctrl+F`, :kbd:`⌘+F`
-   "Remove selected item", :kbd:`Del`, :kbd:`Del` |br| |nl| :kbd:`⌘+⌫`
+.. only:: html
 
+   .. csv-table::
+      :width: 100%
+      :widths: 50 25 25
+      :header: "**Action**", "**Windows / Linux**", "**macOS**"
+
+      "Focus search", :kbd:`Ctrl+F`, :kbd:`⌘+F`
+      "Remove selected item", :kbd:`Del`, :kbd:`Del` |br| |nl| :kbd:`⌘+⌫`
+
+.. only:: latex
+
+   .. csv-table::
+      :width: 100%
+      :widths: 50 25 25
+      :header: "**Action**", "**Windows / Linux**", "**macOS**"
+
+      "Focus search", "Ctrl+F", "⌘+F"
+      "Remove selected item", Del, "Del |br| |nl| ⌘+⌫"
 
 Script editor
 -------------
 
-.. csv-table::
-   :width: 100%
-   :widths: 50 25 25
-   :header: "**Action**", "**Windows / Linux**", "**macOS**"
+.. only:: html
 
-   "Show auto completion", :kbd:`Ctrl+Space`, :kbd:`⌃+Space`
-   "Use selected completion", :kbd:`Tab` |br| |nl| :kbd:`Return`, :kbd:`Tab` |br| |nl| :kbd:`Return`
-   "Hide completions", :kbd:`Esc`, :kbd:`Esc`
+   .. csv-table::
+      :width: 100%
+      :widths: 50 25 25
+      :header: "**Action**", "**Windows / Linux**", "**macOS**"
+
+      "Show auto completion", :kbd:`Ctrl+Space`, :kbd:`⌃+Space`
+      "Use selected completion", :kbd:`Tab` |br| |nl| :kbd:`Return`, :kbd:`Tab` |br| |nl| :kbd:`Return`
+      "Hide completions", :kbd:`Esc`, :kbd:`Esc`
+
+.. only:: latex
+
+   .. csv-table::
+      :width: 100%
+      :widths: 50 25 25
+      :header: "**Action**", "**Windows / Linux**", "**macOS**"
+
+      "Show auto completion", "Ctrl+Space", "⌃+Space"
+      "Use selected completion", "Tab |br| |nl| Return", "Tab |br| |nl| Return"
+      "Hide completions", "Esc", "Esc"
 
 .. raw:: latex
 

--- a/appendices/keyboard_shortcuts.rst
+++ b/appendices/keyboard_shortcuts.rst
@@ -19,216 +19,105 @@ Main window
 File
 ++++++
 
-.. only:: html
+.. csv-table::
+   :width: 100%
+   :widths: 50 25 25
+   :header: "**Action**", "**Windows / Linux**", "**macOS**"
 
-   .. csv-table::
-      :width: 100%
-      :widths: 50 25 25
-      :header: "**Action**", "**Windows / Linux**", "**macOS**"
-
-      "Add folder", :kbd:`Ctrl+E`, :kbd:`⌘+E`
-      "Add files", :kbd:`Ctrl+O`, :kbd:`⌘+O`
-      "Save selected files", :kbd:`Ctrl+S`, :kbd:`⌘+S`
-      "Quit Picard", :kbd:`Ctrl+Q`, :kbd:`⌘+Q`
-
-.. only:: latex
-
-   .. csv-table::
-      :width: 100%
-      :widths: 50 25 25
-      :header: "**Action**", "**Windows / Linux**", "**macOS**"
-
-      "Add folder", "Ctrl+E", "⌘+E"
-      "Add files", "Ctrl+O", "⌘+O"
-      "Save selected files", "Ctrl+S", "⌘+S"
-      "Quit Picard", "Ctrl+Q", "⌘+Q"
+   "Add folder", :kbd:`Ctrl+E`, :kbd:`⌘+E`
+   "Add files", :kbd:`Ctrl+O`, :kbd:`⌘+O`
+   "Save selected files", :kbd:`Ctrl+S`, :kbd:`⌘+S`
+   "Quit Picard", :kbd:`Ctrl+Q`, :kbd:`⌘+Q`
 
 Edit
 ++++++
 
-.. only:: html
+.. csv-table::
+   :width: 100%
+   :widths: 50 25 25
+   :header: "**Action**", "**Windows / Linux**", "**macOS**"
 
-   .. csv-table::
-      :width: 100%
-      :widths: 50 25 25
-      :header: "**Action**", "**Windows / Linux**", "**macOS**"
-
-      "Cut selected files", :kbd:`Ctrl+X`, :kbd:`⌘+X`
-      "Paste selected files", :kbd:`Ctrl+V`, :kbd:`⌘+V`
-      "Show info for selected item", :kbd:`Ctrl+I`, :kbd:`⌘+I`
-
-.. only:: latex
-
-   .. csv-table::
-      :width: 100%
-      :widths: 50 25 25
-      :header: "**Action**", "**Windows / Linux**", "**macOS**"
-
-      "Cut selected files", "Ctrl+X", "⌘+X"
-      "Paste selected files", "Ctrl+V", "⌘+V"
-      "Show info for selected item", "Ctrl+I", "⌘+I"
+   "Cut selected files", :kbd:`Ctrl+X`, :kbd:`⌘+X`
+   "Paste selected files", :kbd:`Ctrl+V`, :kbd:`⌘+V`
+   "Show info for selected item", :kbd:`Ctrl+I`, :kbd:`⌘+I`
 
 View
 ++++++++
 
-.. only:: html
+.. csv-table::
+   :width: 100%
+   :widths: 50 25 25
+   :header: "**Action**", "**Windows / Linux**", "**macOS**"
 
-   .. csv-table::
-      :width: 100%
-      :widths: 50 25 25
-      :header: "**Action**", "**Windows / Linux**", "**macOS**"
-
-      "Toggle file browser", :kbd:`Ctrl+B`, :kbd:`⌘+B`
-      "Toggle metadata view", :kbd:`Ctrl+Shift+M`, :kbd:`⌘+⇧+M`
-
-.. only:: latex
-
-   .. csv-table::
-      :width: 100%
-      :widths: 50 25 25
-      :header: "**Action**", "**Windows / Linux**", "**macOS**"
-
-      "Toggle file browser", "Ctrl+B", "⌘+B"
-      "Toggle metadata view", "Ctrl+Shift+M", "⌘+⇧+M"
+   "Toggle file browser", :kbd:`Ctrl+B`, :kbd:`⌘+B`
+   "Toggle metadata view", :kbd:`Ctrl+Shift+M`, :kbd:`⌘+⇧+M`
 
 Tools
 +++++++++++
 
-.. only:: html
+.. csv-table::
+   :width: 100%
+   :widths: 50 25 25
+   :header: "**Action**", "**Windows / Linux**", "**macOS**"
 
-   .. csv-table::
-      :width: 100%
-      :widths: 50 25 25
-      :header: "**Action**", "**Windows / Linux**", "**macOS**"
-
-      "Refresh", :kbd:`Ctrl+R`, :kbd:`⌘+R`
-      "Lookup CD", :kbd:`Ctrl+K`, :kbd:`⌘+K`
-      "Lookup", :kbd:`Ctrl+L`, :kbd:`⌘+L`
-      "Scan", :kbd:`Ctrl+Y`, :kbd:`⌘+Y`
-      "Cluster", :kbd:`Ctrl+U`, :kbd:`⌘+U`
-      "Lookup in browser", :kbd:`Ctrl+Shift+L`, :kbd:`⌘+⇧+L`
-      "Search for similar tracks", :kbd:`Ctrl+T`, :kbd:`⌘+T`
-      "Generate AcoustID fingerprints", :kbd:`Ctrl+Shift+Y`, :kbd:`⌘+⇧+Y`
-      "Tags from file names", :kbd:`Ctrl+Shift+T`, :kbd:`⌘+⇧+T`
-
-.. only:: latex
-
-   .. csv-table::
-      :width: 100%
-      :widths: 50 25 25
-      :header: "**Action**", "**Windows / Linux**", "**macOS**"
-
-      "Refresh", "Ctrl+R", "⌘+R"
-      "Lookup CD", "Ctrl+K", "⌘+K"
-      "Lookup", "Ctrl+L", "⌘+L"
-      "Scan", "Ctrl+Y", "⌘+Y"
-      "Cluster", "Ctrl+U", "⌘+U"
-      "Lookup in browser", "Ctrl+Shift+L", "⌘+⇧+L"
-      "Search for similar tracks", "Ctrl+T", "⌘+T"
-      "Generate AcoustID fingerprints", "Ctrl+Shift+Y", "⌘+⇧+Y"
-      "Tags from file names", "Ctrl+Shift+T", "⌘+⇧+T"
+   "Refresh", :kbd:`Ctrl+R`, :kbd:`⌘+R`
+   "Lookup CD", :kbd:`Ctrl+K`, :kbd:`⌘+K`
+   "Lookup", :kbd:`Ctrl+L`, :kbd:`⌘+L`
+   "Scan", :kbd:`Ctrl+Y`, :kbd:`⌘+Y`
+   "Cluster", :kbd:`Ctrl+U`, :kbd:`⌘+U`
+   "Lookup in browser", :kbd:`Ctrl+Shift+L`, :kbd:`⌘+⇧+L`
+   "Search for similar tracks", :kbd:`Ctrl+T`, :kbd:`⌘+T`
+   "Generate AcoustID fingerprints", :kbd:`Ctrl+Shift+Y`, :kbd:`⌘+⇧+Y`
+   "Tags from file names", :kbd:`Ctrl+Shift+T`, :kbd:`⌘+⇧+T`
 
 Help
 +++++++++
 
-.. only:: html
+.. csv-table::
+   :width: 100%
+   :widths: 50 25 25
+   :header: "**Action**", "**Windows / Linux**", "**macOS**"
 
-   .. csv-table::
-      :width: 100%
-      :widths: 50 25 25
-      :header: "**Action**", "**Windows / Linux**", "**macOS**"
-
-      "Help", :kbd:`F1`, :kbd:`⌘+?`
-      "View activity history", :kbd:`Ctrl+H`, :kbd:`⌘+⇧+H`
-      "View error/debug log", :kbd:`Ctrl+G`, :kbd:`⌘+G`
-
-.. only:: latex
-
-   .. csv-table::
-      :width: 100%
-      :widths: 50 25 25
-      :header: "**Action**", "**Windows / Linux**", "**macOS**"
-
-      "Help", "F1", "⌘+?"
-      "View activity history", "Ctrl+H", "⌘+⇧+H"
-      "View error/debug log", "Ctrl+G", "⌘+G"
+   "Help", :kbd:`F1`, :kbd:`⌘+?`
+   "View activity history", :kbd:`Ctrl+H`, :kbd:`⌘+⇧+H`
+   "View error/debug log", :kbd:`Ctrl+G`, :kbd:`⌘+G`
 
 Metadata view
 +++++++++++++++
 
-.. only:: html
+.. csv-table::
+   :width: 100%
+   :widths: 50 25 25
+   :header: "**Action**", "**Windows / Linux**", "**macOS**"
 
-   .. csv-table::
-      :width: 100%
-      :widths: 50 25 25
-      :header: "**Action**", "**Windows / Linux**", "**macOS**"
-
-      "Add new tag", :kbd:`Alt+Shift+A`, :kbd:`⌥+⇧+A`
-      "Edit selected tag", :kbd:`Alt+Shift+E`, :kbd:`⌥+⇧+E`
-      "Remove selected tag", :kbd:`Alt+Shift+R` |br| |nl| :kbd:`Del`, :kbd:`⌥+⇧+R` |br| |nl| :kbd:`Del` |br| |nl| :kbd:`⌘+⌫`
-      "Copy selected tag value", :kbd:`Ctrl+C`, :kbd:`⌘+C`
-      "Paste to selected tag value", :kbd:`Ctrl+V`, :kbd:`⌘+V`
-
-.. only:: latex
-
-   .. csv-table::
-      :width: 100%
-      :widths: 50 25 25
-      :header: "**Action**", "**Windows / Linux**", "**macOS**"
-
-      "Add new tag", "Alt+Shift+A", "⌥+⇧+A"
-      "Edit selected tag", "Alt+Shift+E", "⌥+⇧+E"
-      "Remove selected tag", "Alt+Shift+R |br| |nl| Del", "⌥+⇧+R |br| |nl| Del |br| |nl| ⌘+⌫"
-      "Copy selected tag value", :kbd:`Ctrl+C`, :kbd:`⌘+C`
-      "Paste to selected tag value", "Ctrl+V", "⌘+V"
+   "Add new tag", :kbd:`Alt+Shift+A`, :kbd:`⌥+⇧+A`
+   "Edit selected tag", :kbd:`Alt+Shift+E`, :kbd:`⌥+⇧+E`
+   "Remove selected tag", :kbd:`Alt+Shift+R` |br| |nl| :kbd:`Del`, :kbd:`⌥+⇧+R` |br| |nl| :kbd:`Del` |br| |nl| :kbd:`⌘+⌫`
+   "Copy selected tag value", :kbd:`Ctrl+C`, :kbd:`⌘+C`
+   "Paste to selected tag value", :kbd:`Ctrl+V`, :kbd:`⌘+V`
 
 Other
 ++++++++++++++
 
-.. only:: html
+.. csv-table::
+   :width: 100%
+   :widths: 50 25 25
+   :header: "**Action**", "**Windows / Linux**", "**macOS**"
 
-   .. csv-table::
-      :width: 100%
-      :widths: 50 25 25
-      :header: "**Action**", "**Windows / Linux**", "**macOS**"
-
-      "Focus search", :kbd:`Ctrl+F`, :kbd:`⌘+F`
-      "Remove selected item", :kbd:`Del`, :kbd:`Del` |br| |nl| :kbd:`⌘+⌫`
-
-.. only:: latex
-
-   .. csv-table::
-      :width: 100%
-      :widths: 50 25 25
-      :header: "**Action**", "**Windows / Linux**", "**macOS**"
-
-      "Focus search", "Ctrl+F", "⌘+F"
-      "Remove selected item", Del, "Del |br| |nl| ⌘+⌫"
+   "Focus search", :kbd:`Ctrl+F`, :kbd:`⌘+F`
+   "Remove selected item", :kbd:`Del`, :kbd:`Del` |br| |nl| :kbd:`⌘+⌫`
 
 Script editor
 -------------
 
-.. only:: html
+.. csv-table::
+   :width: 100%
+   :widths: 50 25 25
+   :header: "**Action**", "**Windows / Linux**", "**macOS**"
 
-   .. csv-table::
-      :width: 100%
-      :widths: 50 25 25
-      :header: "**Action**", "**Windows / Linux**", "**macOS**"
-
-      "Show auto completion", :kbd:`Ctrl+Space`, :kbd:`⌃+Space`
-      "Use selected completion", :kbd:`Tab` |br| |nl| :kbd:`Return`, :kbd:`Tab` |br| |nl| :kbd:`Return`
-      "Hide completions", :kbd:`Esc`, :kbd:`Esc`
-
-.. only:: latex
-
-   .. csv-table::
-      :width: 100%
-      :widths: 50 25 25
-      :header: "**Action**", "**Windows / Linux**", "**macOS**"
-
-      "Show auto completion", "Ctrl+Space", "⌃+Space"
-      "Use selected completion", "Tab |br| |nl| Return", "Tab |br| |nl| Return"
-      "Hide completions", "Esc", "Esc"
+   "Show auto completion", :kbd:`Ctrl+Space`, :kbd:`⌃+Space`
+   "Use selected completion", :kbd:`Tab` |br| |nl| :kbd:`Return`, :kbd:`Tab` |br| |nl| :kbd:`Return`
+   "Hide completions", :kbd:`Esc`, :kbd:`Esc`
 
 .. raw:: latex
 

--- a/appendices/keyboard_shortcuts.rst
+++ b/appendices/keyboard_shortcuts.rst
@@ -24,10 +24,10 @@ File
    :widths: 50 25 25
    :header: "**Action**", "**Windows / Linux**", "**macOS**"
 
-   "Add folder", "Ctrl+E", "⌘+E"
-   "Add files", "Ctrl+O", "⌘+O"
-   "Save selected files", "Ctrl+S", "⌘+S"
-   "Quit Picard", "Ctrl+Q", "⌘+Q"
+   "Add folder", :kbd:`Ctrl+E`, :kbd:`⌘+E`
+   "Add files", :kbd:`Ctrl+O`, :kbd:`⌘+O`
+   "Save selected files", :kbd:`Ctrl+S`, :kbd:`⌘+S`
+   "Quit Picard", :kbd:`Ctrl+Q`, :kbd:`⌘+Q`
 
 Edit
 ++++++
@@ -37,9 +37,9 @@ Edit
    :widths: 50 25 25
    :header: "**Action**", "**Windows / Linux**", "**macOS**"
 
-   "Cut selected files", "Ctrl+X", "⌘+X"
-   "Paste selected files", "Ctrl+V", "⌘+V"
-   "Show info for selected item", "Ctrl+I", "⌘+I"
+   "Cut selected files", :kbd:`Ctrl+X`, :kbd:`⌘+X`
+   "Paste selected files", :kbd:`Ctrl+V`, :kbd:`⌘+V`
+   "Show info for selected item", :kbd:`Ctrl+I`, :kbd:`⌘+I`
 
 View
 ++++++++
@@ -48,8 +48,8 @@ View
    :widths: 50 25 25
    :header: "**Action**", "**Windows / Linux**", "**macOS**"
 
-   "Toggle file browser", "Ctrl+B", "⌘+B"
-   "Toggle metadata view", "Ctrl+Shift+M", "⌘+⇧+M"
+   "Toggle file browser", :kbd:`Ctrl+B`, :kbd:`⌘+B`
+   "Toggle metadata view", :kbd:`Ctrl+Shift+M`, :kbd:`⌘+⇧+M`
 
 Tools
 +++++++++++
@@ -58,15 +58,15 @@ Tools
    :widths: 50 25 25
    :header: "**Action**", "**Windows / Linux**", "**macOS**"
 
-   "Refresh", "Ctrl+R", "⌘+R"
-   "Lookup CD", "Ctrl+K", "⌘+K"
-   "Lookup", "Ctrl+L", "⌘+L"
-   "Scan", "Ctrl+Y", "⌘+Y"
-   "Cluster", "Ctrl+U", "⌘+U"
-   "Lookup in browser", "Ctrl+Shift+L", "⌘+⇧+L"
-   "Search for similar tracks", "Ctrl+T", "⌘+T"
-   "Generate AcoustID fingerprints", "Ctrl+Shift+Y", "⌘+⇧+Y"
-   "Tags from file names", "Ctrl+Shift+T", "⌘+⇧+T"
+   "Refresh", :kbd:`Ctrl+R`, :kbd:`⌘+R`
+   "Lookup CD", :kbd:`Ctrl+K`, :kbd:`⌘+K`
+   "Lookup", :kbd:`Ctrl+L`, :kbd:`⌘+L`
+   "Scan", :kbd:`Ctrl+Y`, :kbd:`⌘+Y`
+   "Cluster", :kbd:`Ctrl+U`, :kbd:`⌘+U`
+   "Lookup in browser", :kbd:`Ctrl+Shift+L`, :kbd:`⌘+⇧+L`
+   "Search for similar tracks", :kbd:`Ctrl+T`, :kbd:`⌘+T`
+   "Generate AcoustID fingerprints", :kbd:`Ctrl+Shift+Y`, :kbd:`⌘+⇧+Y`
+   "Tags from file names", :kbd:`Ctrl+Shift+T`, :kbd:`⌘+⇧+T`
 
 Help
 +++++++++
@@ -75,9 +75,9 @@ Help
    :widths: 50 25 25
    :header: "**Action**", "**Windows / Linux**", "**macOS**"
 
-   "Help", "F1", "⌘+?"
-   "View activity history", "Ctrl+H", "⌘+⇧+H"
-   "View error/debug log", "Ctrl+G", "⌘+G"
+   "Help", :kbd:`F1`, :kbd:`⌘+?`
+   "View activity history", :kbd:`Ctrl+H`, :kbd:`⌘+⇧+H`
+   "View error/debug log", :kbd:`Ctrl+G`, :kbd:`⌘+G`
 
 Metadata view
 +++++++++++++++
@@ -86,11 +86,11 @@ Metadata view
    :widths: 50 25 25
    :header: "**Action**", "**Windows / Linux**", "**macOS**"
 
-   "Add new tag", "Alt+Shift+A", "⌥+⇧+A"
-   "Edit selected tag", "Alt+Shift+E", "⌥+⇧+E"
-   "Remove selected tag", "Alt+Shift+R |br| |nl| Del", "⌥+⇧+R |br| |nl| Del |br| |nl| ⌘+⌫"
-   "Copy selected tag value", "Ctrl+C", "⌘+C"
-   "Paste to selected tag value", "Ctrl+V", "⌘+V"
+   "Add new tag", :kbd:`Alt+Shift+A`, :kbd:`⌥+⇧+A`
+   "Edit selected tag", :kbd:`Alt+Shift+E`, :kbd:`⌥+⇧+E`
+   "Remove selected tag", :kbd:`Alt+Shift+R` |br| |nl| :kbd:`Del`, :kbd:`⌥+⇧+R` |br| |nl| :kbd:`Del` |br| |nl| :kbd:`⌘+⌫`
+   "Copy selected tag value", :kbd:`Ctrl+C`, :kbd:`⌘+C`
+   "Paste to selected tag value", :kbd:`Ctrl+V`, :kbd:`⌘+V`
 
 Other
 ++++++++++++++
@@ -99,8 +99,8 @@ Other
    :widths: 50 25 25
    :header: "**Action**", "**Windows / Linux**", "**macOS**"
 
-   "Focus search", "Ctrl+F", "⌘+F"
-   "Remove selected item", "Del", "Del |br| |nl| ⌘+⌫"
+   "Focus search", :kbd:`Ctrl+F`, :kbd:`⌘+F`
+   "Remove selected item", :kbd:`Del`, :kbd:`Del` |br| |nl| :kbd:`⌘+⌫`
 
 
 Script editor
@@ -111,9 +111,9 @@ Script editor
    :widths: 50 25 25
    :header: "**Action**", "**Windows / Linux**", "**macOS**"
 
-   "Show auto completion", "Ctrl+Space", "⌃+Space"
-   "Use selected completion", "Tab |br| |nl| Return", "Tab |br| |nl| Return"
-   "Hide completions", "Esc", "Esc"
+   "Show auto completion", :kbd:`Ctrl+Space`, :kbd:`⌃+Space`
+   "Use selected completion", :kbd:`Tab` |br| |nl| :kbd:`Return`, :kbd:`Tab` |br| |nl| :kbd:`Return`
+   "Hide completions", :kbd:`Esc`, :kbd:`Esc`
 
 .. raw:: latex
 

--- a/conf.py
+++ b/conf.py
@@ -167,6 +167,8 @@ latex_elements = {
     'preamble': r'''\hyphenation{Music-Brainz}
 \usepackage{fontspec}
 \setmainfont{DejaVu Sans}
+\setsansfont{DejaVu Sans}
+\setmonofont{DejaVu Sans Mono}
 \newcommand\sphinxbackoftitlepage{''' + my_notice + r'''}
 ''',
     'extraclassoptions': 'openany',


### PR DESCRIPTION
<!--
    Thank-you for submitting a pull request. Your effort and input is appreciated.

    Please use this template to help us review your change. Not everything is
    required for every change, so please feel free to omit any sections that
    are not relevant to your change.

    Also, please ensure that you've reviewed the guidelines in CONTRIBUTING.md.
-->

### Summary

This is a…

- [ ] Correction
- [ ] Addition
- [x] Restructuring
- [ ] Minor / simple change (like a typo)
- [ ] Other

### Reason for the Change

Make use of the `:kbd:` role for designating keyboard shortcuts.

### Description of the Change

Use the `:kbd:` role for the keyboard shortcuts page, and also add some CSS styling for nicer rendering of those.

Here is a screenshot how this renders on Firefox on Windows:

![grafik](https://user-images.githubusercontent.com/29852/116739433-f7888b00-a9f3-11eb-9164-aa82b1c9c755.png)

Also this formatting applies to other places where `:kbd:` role is being used in text, e.g.:

![grafik](https://user-images.githubusercontent.com/29852/116739560-1b4bd100-a9f4-11eb-96fa-ef7af2f368c7.png)

### Additional actions required

I could not check how this ends up in the epub or PDF. epub should just render the same as the normal HTML I guess. And in the Latex generated documents the `:kbd:`  role likely just is rendered also in a monospaced font.