### PR TITLE
Tagger Script syntax highlight

### DIFF
--- a/_extensions/taggerscript.py
+++ b/_extensions/taggerscript.py
@@ -1,0 +1,44 @@
+# -*- coding: utf-8 -*-
+"""Sphinx extension to add a Picard Tagger Script lexer.
+"""
+
+from pygments.lexer import RegexLexer
+from pygments.token import (
+    Comment,
+    Keyword,
+    Name,
+    String,
+    Text,
+)
+from sphinx.application import Sphinx
+
+
+class TaggerScriptLexer(RegexLexer):
+    """Pygments lexer for Picard Tagger Script syntax.
+    """
+    name = 'Tagger script lexer'
+    aliases = ['taggerscript']
+    filenames = ['*.pts']
+
+    tokens = {
+        'root': [
+            (r'[^\$%\\)]+', Text),
+            (r'\\.', String.Escape),
+            (r'\$noop\(', Comment.Multiline, 'comment'),
+            (r'\$[A-Za-z_0-9]+\(', Keyword),
+            (r'%[A-Za-z_0-9]+%', Name),
+            (r'\)', Keyword),
+        ],
+        'comment': [
+            (r'[^\$\\)]+', Comment.Multiline),
+            (r'\\.', Comment.Multiline),
+            (r'\$[A-Za-z_0-9]+\(', Comment.Multiline, '#push'),
+            (r'\)', Comment.Multiline, '#pop'),
+        ],
+    }
+
+
+def setup(sphinx: Sphinx):
+    """Setup method to initialize this extension.
+    """
+    sphinx.add_lexer('taggerscript', TaggerScriptLexer())

--- a/_static/css/extra.css
+++ b/_static/css/extra.css
@@ -57,7 +57,6 @@ table.colwidths-given.docutils.align-default tbody tr td {
 }
 
 /* adds formatting for keyboard shortcuts */
-
 kbd.compound {
     white-space: nowrap;
 }
@@ -74,4 +73,21 @@ kbd:not(.compound) {
     box-shadow: inset 0 -1px 0 #ddd;
     line-height: 1em;
     font-size: .9em;
+}
+
+/* Extended syntax highlighting for Picard Tagger Script */
+.highlight-taggerscript .k {
+    color: rgb(0, 0, 255); /* function */
+}
+
+.highlight-taggerscript .n {
+    color: rgb(0, 128, 128); /* variable */
+}
+
+.highlight-taggerscript .se {
+    color: rgb(128, 0, 0); /* escape */
+}
+
+.highlight-taggerscript .cm {
+    color: rgb(128, 128, 128); /* noop */
 }

--- a/conf.py
+++ b/conf.py
@@ -7,17 +7,17 @@
 # pylint: disable=missing-module-docstring
 
 
+import datetime
+import os
+import re
+import sys
+
 # -- Path setup --------------------------------------------------------------
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
-# import os
-# import sys
-# sys.path.insert(0, os.path.abspath('.'))
-
-import datetime
-import re
+sys.path.insert(0, os.path.abspath('_extensions'))
 
 # import sphinx_rtd_theme
 # import picard_theme
@@ -70,6 +70,7 @@ master_doc = 'index'
 extensions = [
     "recommonmark",
     "notfound.extension",
+    "taggerscript",
     # "sphinx_rtd_theme",
     # "picard_theme",
 ]
@@ -280,3 +281,5 @@ notfound_context = {
     'title': notfound_title,
     'body': "\n<h1>" + notfound_title + "</h1>\n<p>\n" + notfound_text_1 + "\n</p>\n<div id='content'></div>\n<p>\n" + notfound_text_2 + "\n</p>\n" + notfound_script,
 }
+
+highlight_language = 'taggerscript'

--- a/functions/func_add.rst
+++ b/functions/func_add.rst
@@ -13,7 +13,9 @@ Returns an empty string if an argument is missing or not an integer.
 
 **Example:**
 
-The following statements will return the values indicated::
+The following statements will return the values indicated:
+
+.. code-block:: taggerscript
 
     $add(20,15)      ==>  "35"
     $add(20,-15)     ==>  "5"

--- a/functions/func_and.rst
+++ b/functions/func_and.rst
@@ -14,7 +14,9 @@ of arguments. The result is true if **ALL** of the arguments are not empty.
 
 **Example:**
 
-The following statements will return the values indicated::
+The following statements will return the values indicated:
+
+.. code-block:: taggerscript
 
     $set(test,x)
     $and(%test%,)          ==>  ""   (False)

--- a/functions/func_copy.rst
+++ b/functions/func_copy.rst
@@ -17,7 +17,9 @@ Note that if the variable ``target`` already exists, it will be overwritten by `
 
 **Example:**
 
-The following statements will yield the values for ``target`` as indicated::
+The following statements will yield the values for ``target`` as indicated:
+
+.. code-block:: taggerscript
 
     $set(source,)
     $set(target,This will be overwritten)

--- a/functions/func_copymerge.rst
+++ b/functions/func_copymerge.rst
@@ -19,7 +19,9 @@ in percent signs '%'.
 
 **Example:**
 
-The following statements will yield the values for ``target`` as indicated::
+The following statements will yield the values for ``target`` as indicated:
+
+.. code-block:: taggerscript
 
     $set(target,)
     $set(source,one)

--- a/functions/func_datetime.rst
+++ b/functions/func_datetime.rst
@@ -25,7 +25,9 @@ examples below.
 
 **Example:**
 
-The following statements will return the values indicated::
+The following statements will return the values indicated:
+
+.. code-block:: taggerscript
 
    $datetime()                         ==>  "2020-02-15 14:26:32"
    $datetime(\%Y-\%m-\%d \%H:\%M:\%S)  ==>  "2020-02-15 14:26:32"

--- a/functions/func_delete.rst
+++ b/functions/func_delete.rst
@@ -17,6 +17,8 @@ running ``$delete(genre)`` will actually remove the "genre" tag from a file when
 
 **Example:**
 
-The following statements will perform the actions indicated::
+The following statements will perform the actions indicated:
+
+.. code-block:: taggerscript
 
     $delete(genre)  ==>  Remove the "genre" tag from a file when saving

--- a/functions/func_delprefix.rst
+++ b/functions/func_delprefix.rst
@@ -16,7 +16,9 @@ default. Note that the matching is case-sensitive.
 
 **Example:**
 
-The following statements will return the values indicated::
+The following statements will return the values indicated:
+
+.. code-block:: taggerscript
 
     $delprefix(The Beatles)       ==>  "Beatles"
     $delprefix(The Beatles,)      ==>  "The Beatles"

--- a/functions/func_div.rst
+++ b/functions/func_div.rst
@@ -16,7 +16,9 @@ argument is zero, the function will return an empty string.
 
 **Example:**
 
-The following statements will return the values indicated::
+The following statements will return the values indicated:
+
+.. code-block:: taggerscript
 
     $div(10,3)      ==> "3"
     $div(10,-3)     ==> "-4"

--- a/functions/func_endswith.rst
+++ b/functions/func_endswith.rst
@@ -14,7 +14,9 @@ Returns true if ``text`` ends with ``suffix``.  Note that the comparison is case
 
 **Example:**
 
-The statements below return the values indicated::
+The statements below return the values indicated:
+
+.. code-block:: taggerscript
 
     $endswith(The time is now,is now)  ==>  "1"  (True)
     $endswith(The time is now,is NOW)  ==>  ""   (False)

--- a/functions/func_eq.rst
+++ b/functions/func_eq.rst
@@ -14,7 +14,9 @@ Returns true if ``x`` equals ``y``.  Note that comparisons are case-sensitive.
 
 **Example:**
 
-The following statements will return the values indicated::
+The following statements will return the values indicated:
+
+.. code-block:: taggerscript
 
     $eq(,a)   ==>  ""   (False)
     $eq(a,)   ==>  ""   (False)

--- a/functions/func_eq_all.rst
+++ b/functions/func_eq_all.rst
@@ -16,7 +16,9 @@ Functionally equivalent to ``$and($eq(x,a1),$eq(x,a2) ...)``.
 
 **Example:**
 
-The following statements will return the values indicated::
+The following statements will return the values indicated:
+
+.. code-block:: taggerscript
 
     $eq_all(A,A,B,C)    ==>  ""   (False)
     $eq_all(A,a,A,A)    ==>  ""   (False)

--- a/functions/func_eq_any.rst
+++ b/functions/func_eq_any.rst
@@ -16,7 +16,9 @@ Functionally equivalent to ``$or($eq(x,a1),$eq(x,a2) ...)``.
 
 **Example:**
 
-The following statements will return the values indicated::
+The following statements will return the values indicated:
+
+.. code-block:: taggerscript
 
     $eq_any(A,A,B,C)  ==>  "1"  (True)
     $eq_any(A,a,A,A)  ==>  "1"  (True)

--- a/functions/func_find.rst
+++ b/functions/func_find.rst
@@ -21,7 +21,9 @@ support wildcards.
 
 **Example:**
 
-The following statements will return the values indicated::
+The following statements will return the values indicated:
+
+.. code-block:: taggerscript
 
     $find(abcdef,a)     ==>  "0"
     $find(abcdef,c)     ==>  "2"

--- a/functions/func_firstalphachar.rst
+++ b/functions/func_firstalphachar.rst
@@ -16,7 +16,9 @@ the default value "#" will be used.
 
 **Example:**
 
-The following statements will return the values indicated::
+The following statements will return the values indicated:
+
+.. code-block:: taggerscript
 
     $firstalphachar(abc)             ==>  "A"
     $firstalphachar(123)             ==>  "#"

--- a/functions/func_firstwords.rst
+++ b/functions/func_firstwords.rst
@@ -18,7 +18,9 @@ than the number of characters in ``text``, the function will return an empty str
 
 **Example:**
 
-The following statements will return the values indicated::
+The following statements will return the values indicated:
+
+.. code-block:: taggerscript
 
     $firstwords(Once upon a time,)     ==>  ""
     $firstwords(Once upon a time,0)    ==>  ""

--- a/functions/func_foreach.rst
+++ b/functions/func_foreach.rst
@@ -21,7 +21,9 @@ variable.
 
 **Example:**
 
-The following statements will perform the processing indicated::
+The following statements will perform the processing indicated:
+
+.. code-block:: taggerscript
 
     $noop( Mark all listed tags for deletion from the files. )
     $foreach(genre; comment; year,$delete(%_loop_value%))

--- a/functions/func_get.rst
+++ b/functions/func_get.rst
@@ -16,7 +16,9 @@ variables.
 
 **Example:**
 
-The following statements will return the values indicated::
+The following statements will return the values indicated:
+
+.. code-block:: taggerscript
 
     $set(foo,This is foo)
     $set(bar,foo)

--- a/functions/func_getmulti.rst
+++ b/functions/func_getmulti.rst
@@ -24,7 +24,9 @@ number of elements in ``name``, or a negative number greater than the number of 
 
 **Example:**
 
-The following statements will return the values indicated::
+The following statements will return the values indicated:
+
+.. code-block:: taggerscript
 
     $set(foo,A; B; C)
     $setmulti(bar,A; B; C)

--- a/functions/func_gt.rst
+++ b/functions/func_gt.rst
@@ -15,7 +15,9 @@ not an integer, the function will return an empty string.
 
 **Example:**
 
-The following statements will return the values indicated::
+The following statements will return the values indicated:
+
+.. code-block:: taggerscript
 
     $gt(-1,0)   ==>  ""   (False)
     $gt(0,0)    ==>  ""   (False)

--- a/functions/func_gte.rst
+++ b/functions/func_gte.rst
@@ -15,7 +15,9 @@ not an integer, the function will return an empty string.
 
 **Example:**
 
-The following statements will return the values indicated::
+The following statements will return the values indicated:
+
+.. code-block:: taggerscript
 
     $gte(-1,0)   ==>  ""   (False)
     $gte(0,0)    ==>  "1"  (True)

--- a/functions/func_if.rst
+++ b/functions/func_if.rst
@@ -15,7 +15,9 @@ is not provided, it will be assumed to be an empty string.  In addition to (or i
 
 **Example:**
 
-The following statements will return the values indicated::
+The following statements will return the values indicated:
+
+.. code-block:: taggerscript
 
     $set(foo,This is foo)
     $set(bar,)

--- a/functions/func_if2.rst
+++ b/functions/func_if2.rst
@@ -13,7 +13,9 @@ Returns the first non empty argument.  Can be used with an arbitrary number of a
 
 **Example:**
 
-The following statements will return the values indicated::
+The following statements will return the values indicated:
+
+.. code-block:: taggerscript
 
     $set(foo,)
     $set(bar,Something)

--- a/functions/func_in.rst
+++ b/functions/func_in.rst
@@ -14,7 +14,9 @@ Returns true, if ``x`` contains ``y``.  Note that comparisons are case-sensitive
 
 **Example:**
 
-The following statements will return the values indicated::
+The following statements will return the values indicated:
+
+.. code-block:: taggerscript
 
     $set(foo,ABCDEFG)
     $set(bar,CDE)

--- a/functions/func_initials.rst
+++ b/functions/func_initials.rst
@@ -14,7 +14,9 @@ Returns the first character of each word in ``text``, if it is an alphabetic cha
 
 **Example:**
 
-The following statements will return the values indicated::
+The following statements will return the values indicated:
+
+.. code-block:: taggerscript
 
     $set(foo,This is a test)
     $initials(%foo%)               ==>  "Tiat"

--- a/functions/func_inmulti.rst
+++ b/functions/func_inmulti.rst
@@ -15,7 +15,9 @@ Note that comparisons are case-sensitive.
 
 **Example:**
 
-The following statements will return the values indicated::
+The following statements will return the values indicated:
+
+.. code-block:: taggerscript
 
     $setmulti(foo,One; Two; Three)
     $set(bar,Two)

--- a/functions/func_is_audio.rst
+++ b/functions/func_is_audio.rst
@@ -14,7 +14,9 @@ Returns true, if the track being processed is not shown as being a video.
 
 **Example:**
 
-The following statements will return the values indicated::
+The following statements will return the values indicated:
+
+.. code-block:: taggerscript
 
     $is_audio()  ==>  "1"  (True, if the track is not a video)
     $is_audio()  ==>  ""   (False, if the track is a video)

--- a/functions/func_is_complete.rst
+++ b/functions/func_is_complete.rst
@@ -17,7 +17,9 @@ Returns true if every track in the album is matched to a single file.
 
 **Example:**
 
-The following statements will return the values indicated::
+The following statements will return the values indicated:
+
+.. code-block:: taggerscript
 
     $is_complete()  ==>  "1"  (True, if all tracks have been matched)
     $is_complete()  ==>  ""   (False, if not all tracks have been matched)

--- a/functions/func_is_video.rst
+++ b/functions/func_is_video.rst
@@ -14,7 +14,9 @@ Returns true, if the track being processed is shown as being a video.
 
 **Example:**
 
-The following statements will return the values indicated::
+The following statements will return the values indicated:
+
+.. code-block:: taggerscript
 
     $is_video()  ==>  "1"  (True, if the track is a video)
     $is_video()  ==>  ""   (False, if the track is not a video)

--- a/functions/func_join.rst
+++ b/functions/func_join.rst
@@ -17,7 +17,9 @@ space "; " if not passed) to coerce the value into a proper multi-valued variabl
 
 **Example:**
 
-The following statements will return the values indicated::
+The following statements will return the values indicated:
+
+.. code-block:: taggerscript
 
     $set(foo,First:A; Second:B)
     $join(%foo%, >> )                     ==>  "First:A; Second:B"

--- a/functions/func_left.rst
+++ b/functions/func_left.rst
@@ -16,7 +16,9 @@ than the number of characters in ``text``, the function will return an empty str
 
 **Example:**
 
-The following statements will return the values indicated::
+The following statements will return the values indicated:
+
+.. code-block:: taggerscript
 
     $left(,)       ==>  ""
     $left(ABC,)    ==>  ""

--- a/functions/func_len.rst
+++ b/functions/func_len.rst
@@ -13,7 +13,9 @@ Returns the number of characters in ``text``.
 
 **Example:**
 
-The following statements will return the values indicated::
+The following statements will return the values indicated:
+
+.. code-block:: taggerscript
 
     $set(foo,)
     $len(%foo%)    ==>  "0"

--- a/functions/func_lenmulti.rst
+++ b/functions/func_lenmulti.rst
@@ -18,7 +18,9 @@ will return "1".
 
 **Example:**
 
-The following statements will return the values indicated::
+The following statements will return the values indicated:
+
+.. code-block:: taggerscript
 
     $set(foo,)
     $lenmulti(%foo%)            ==>  "0"

--- a/functions/func_lower.rst
+++ b/functions/func_lower.rst
@@ -14,6 +14,8 @@ Returns ``text`` in lower case.
 
 **Example:**
 
-The following statement will return the value indicated::
+The following statement will return the value indicated:
+
+.. code-block:: taggerscript
 
     $title(tHe houR is upOn uS)  ==>  "the hour is upon us"

--- a/functions/func_lt.rst
+++ b/functions/func_lt.rst
@@ -14,7 +14,9 @@ not an integer, the function will return an empty string.
 
 **Example:**
 
-The following statements will return the values indicated::
+The following statements will return the values indicated:
+
+.. code-block:: taggerscript
 
     $lte(-1,0)   ==>  "1"  (True)
     $lte(0,0)    ==>  ""   (False)

--- a/functions/func_lte.rst
+++ b/functions/func_lte.rst
@@ -14,7 +14,9 @@ not an integer, the function will return an empty string.
 
 **Example:**
 
-The following statements will return the values indicated::
+The following statements will return the values indicated:
+
+.. code-block:: taggerscript
 
     $lte(-1,0)   ==>  "1"  (True)
     $lte(0,0)    ==>  "1"  (True)

--- a/functions/func_map.rst
+++ b/functions/func_map.rst
@@ -32,7 +32,9 @@ Empty elements are automatically removed from the output.
 
 .. only:: html
 
-   The following statements will return the values indicated::
+   The following statements will return the values indicated:
+
+   .. code-block:: taggerscript
 
        $set(foo,First:A; Second:B)
        $map(%foo%,$upper(%_loop_count%=%_loop_value%))    ==>  "1=FIRST:A; SECOND:B"

--- a/functions/func_matchedtracks.rst
+++ b/functions/func_matchedtracks.rst
@@ -18,6 +18,8 @@ Returns the number of matched tracks within a release.
 
 **Example:**
 
-The following statements will return the values indicated::
+The following statements will return the values indicated:
+
+.. code-block:: taggerscript
 
     $matchedtracks()  ==>  "3" (if three of the tracks were matched)

--- a/functions/func_mod.rst
+++ b/functions/func_mod.rst
@@ -16,7 +16,9 @@ the function will return an empty string.
 
 **Example:**
 
-The following statements will return the values indicated::
+The following statements will return the values indicated:
+
+.. code-block:: taggerscript
 
     $mod(0,3)      ==>  "0"
     $mod(10,3)     ==>  "1"

--- a/functions/func_mul.rst
+++ b/functions/func_mul.rst
@@ -15,7 +15,9 @@ the function will return an empty string.
 
 **Example:**
 
-The following statements will return the values indicated::
+The following statements will return the values indicated:
+
+.. code-block:: taggerscript
 
     $mul(1,2)      ==> "2"
     $mul(1,2,3)    ==> "6"

--- a/functions/func_ne.rst
+++ b/functions/func_ne.rst
@@ -13,7 +13,9 @@ Returns true if ``x`` does not equal ``y``.  Note that comparisons are case-sens
 
 **Example:**
 
-The following statements will return the values indicated::
+The following statements will return the values indicated:
+
+.. code-block:: taggerscript
 
     $ne(,a)   ==>  "1"  (True)
     $ne(a,)   ==>  "1"  (True)

--- a/functions/func_ne_all.rst
+++ b/functions/func_ne_all.rst
@@ -16,7 +16,9 @@ Functionally equivalent to ``$and($ne(x,a1),$ne(x,a2) ...)``.
 
 **Example:**
 
-The following statements will return the values indicated::
+The following statements will return the values indicated:
+
+.. code-block:: taggerscript
 
     $ne_all(A,A,B,C)    ==>  ""   (False)
     $ne_all(A,a,A,A)    ==>  ""   (False)

--- a/functions/func_ne_any.rst
+++ b/functions/func_ne_any.rst
@@ -16,7 +16,9 @@ Functionally equivalent to ``$or($ne(x,a1),$ne(x,a2) ...)``.
 
 **Example:**
 
-The following statements will return the values indicated::
+The following statements will return the values indicated:
+
+.. code-block:: taggerscript
 
     $ne_any(A,A,B,C)    ==>  "1"  (True)
     $ne_any(A,a,A,A)    ==>  "1"  (True)

--- a/functions/func_noop.rst
+++ b/functions/func_noop.rst
@@ -13,7 +13,9 @@ Does nothing and always returns an empty string.  This is useful for comments or
 
 **Example:**
 
-The following statements will return the values indicated::
+The following statements will return the values indicated:
+
+.. code-block:: taggerscript
 
     $noop( A comment. )          ==>  ""
     $noop($set(foo,Testing...))  ==>  "" (and "foo" is not set)

--- a/functions/func_not.rst
+++ b/functions/func_not.rst
@@ -13,7 +13,9 @@ Returns true if ``x`` is empty.
 
 **Example:**
 
-The following statements will return the values indicated::
+The following statements will return the values indicated:
+
+.. code-block:: taggerscript
 
     $set(foo,)
     $not(%foo%)  ==>  "1"   (False)

--- a/functions/func_num.rst
+++ b/functions/func_num.rst
@@ -14,7 +14,9 @@ Returns ``number`` formatted to ``length`` digits, where ``number`` and ``length
 
 **Example:**
 
-The following statements will return the values indicated::
+The following statements will return the values indicated:
+
+.. code-block:: taggerscript
 
     $num(,)        ==>  ""
     $num(,1)       ==>  "0"

--- a/functions/func_or.rst
+++ b/functions/func_or.rst
@@ -14,7 +14,9 @@ of arguments. The result is true if **ANY** of the arguments is not empty.
 
 **Example:**
 
-The following statements will return the values indicated::
+The following statements will return the values indicated:
+
+.. code-block:: taggerscript
 
     $or(,)          ==>  ""   (False)
     $or(,1)         ==>  "1"  (True)

--- a/functions/func_pad.rst
+++ b/functions/func_pad.rst
@@ -17,7 +17,9 @@ return an empty string.
 
 **Example:**
 
-The following statements will return the values indicated::
+The following statements will return the values indicated:
+
+.. code-block:: taggerscript
 
     $pad(abc,5,+)   ==>  "++abc"
     $pad(abc,0,+)   ==>  "abc"

--- a/functions/func_performer.rst
+++ b/functions/func_performer.rst
@@ -19,7 +19,9 @@ matched is case-sensitive.
 
 With the performer tags as ``performer:guitar`` = "Ann", ``performer:rhythm-guitar`` =
 "Bob" and ``performer:drums`` = "Cindy", the following statements will return the
-values indicated::
+values indicated:
+
+.. code-block:: taggerscript
 
     $set(foo,guitar)
     $performer(%foo%)          ==>  "Ann, Bob"

--- a/functions/func_replace.rst
+++ b/functions/func_replace.rst
@@ -13,7 +13,9 @@ Replaces occurrences of ``search`` in ``text`` with ``replace`` and returns the 
 
 **Example:**
 
-The following statements will return the values indicated::
+The following statements will return the values indicated:
+
+.. code-block:: taggerscript
 
     $set(foo,I like cats the best)
     $replace(%foo%,cat,dog)                 ==>  "I like dogs the best"

--- a/functions/func_replacemulti.rst
+++ b/functions/func_replacemulti.rst
@@ -17,7 +17,9 @@ Empty elements are automatically removed from the output.
 
 **Example:**
 
-The following statements will return the values indicated::
+The following statements will return the values indicated:
+
+.. code-block:: taggerscript
 
     $setmulti(foo,Electronic; Idm; Techno)
     $replacemulti(%foo%,Idm,IDM)                ==>  "Electronic; IDM; Techno"

--- a/functions/func_reverse.rst
+++ b/functions/func_reverse.rst
@@ -13,7 +13,9 @@ Returns ``text`` in reverse order.
 
 **Example:**
 
-The following statements will return the values indicated::
+The following statements will return the values indicated:
+
+.. code-block:: taggerscript
 
     $set(foo,abcde)
     $reverse(%foo%)  ==>  "edcba"

--- a/functions/func_reversemulti.rst
+++ b/functions/func_reversemulti.rst
@@ -19,7 +19,9 @@ This function can be used in conjunction with the ``$sortmulti`` function to sor
 
 **Example:**
 
-The following statements will return the values indicated::
+The following statements will return the values indicated:
+
+.. code-block:: taggerscript
 
     $set(foo,A; B; C; D; E)
     $reversemulti(%foo%)            ==>  "A; B; C; D; E"

--- a/functions/func_right.rst
+++ b/functions/func_right.rst
@@ -16,7 +16,9 @@ than the number of characters in ``text``, the function will return an empty str
 
 **Example:**
 
-The following statements will return the values indicated::
+The following statements will return the values indicated:
+
+.. code-block:: taggerscript
 
     $right(abcd,2)   ==>  "cd"
     $right(abcd,0)   ==>  "cd"

--- a/functions/func_rreplace.rst
+++ b/functions/func_rreplace.rst
@@ -22,7 +22,9 @@ please see the `article on Wikipedia <https://wikipedia.org/wiki/Regular_express
 
 **Example:**
 
-The following statements will return the values indicated::
+The following statements will return the values indicated:
+
+.. code-block:: taggerscript
 
     $rreplace(test \(disc 1\),\\s\\\(disc \\d+\\\),)  ==>  "test"
     $rreplace(test,[t,)                               ==>  "test"

--- a/functions/func_rsearch.rst
+++ b/functions/func_rsearch.rst
@@ -29,7 +29,9 @@ expression will be returned.
 
 **Example:**
 
-The following statements will return the values indicated::
+The following statements will return the values indicated:
+
+.. code-block:: taggerscript
 
     $rsearch(test \(disc 1\),\\\(disc \(\\d+\)\\\))  ==>  "1"
     $rsearch(test \(disc 1\),\\\(disc \\d+\\\))      ==>  "(disc 1)"

--- a/functions/func_set.rst
+++ b/functions/func_set.rst
@@ -23,7 +23,9 @@ will be used as ``name``.  This allows the creation of dynamically named variabl
 
 **Example:**
 
-The following statements will return the values indicated::
+The following statements will return the values indicated:
+
+.. code-block:: taggerscript
 
    $set(comment,Testing)  ==>  "Testing" will be written to the "comment" tag
    $set(_hidden,Testing)  ==>  "_hidden" variable will not be written

--- a/functions/func_setmulti.rst
+++ b/functions/func_setmulti.rst
@@ -17,7 +17,9 @@ and then set them back as proper multi-valued variable.
 
 **Example:**
 
-The following statements will return the values indicated::
+The following statements will return the values indicated:
+
+.. code-block:: taggerscript
 
     $setmulti(genre,$lower(%genre%))  ==>  all "genre" elements in lower case
     $setmulti(alpha,A; B; C)          ==>  3 elements ("A", "B" and "C")

--- a/functions/func_slice.rst
+++ b/functions/func_slice.rst
@@ -26,7 +26,9 @@ would look something like ``$setmulti(supporting_artists,$slice(%artists%,1,))``
 
 **Example:**
 
-The following statements will return the values indicated::
+The following statements will return the values indicated:
+
+.. code-block:: taggerscript
 
     $set(foo,A; B; C; D; E)
     $slice(%foo%,1)                        ==>  ""

--- a/functions/func_sortmulti.rst
+++ b/functions/func_sortmulti.rst
@@ -18,7 +18,9 @@ coerce the value into a proper multi-valued variable.  If ``name`` is missing
 
 **Example:**
 
-The following statements will return the values indicated::
+The following statements will return the values indicated:
+
+.. code-block:: taggerscript
 
     $set(foo,B; C; E; D; A)
     $sortmulti(%foo%)                       ==>  "B; C; E; D; A"

--- a/functions/func_startswith.rst
+++ b/functions/func_startswith.rst
@@ -14,7 +14,9 @@ Returns true if ``text`` starts with ``prefix``.  Note that the comparison is ca
 
 **Example:**
 
-The statements below return the values indicated::
+The statements below return the values indicated:
+
+.. code-block:: taggerscript
 
     $startswith(The time is now.,The time)  ==>  "1"  (True)
     $startswith(The time is now.,The TIME)  ==>  ""   (False)

--- a/functions/func_strip.rst
+++ b/functions/func_strip.rst
@@ -15,7 +15,9 @@ Characters such as newlines '\\n', tabs '\\t' and returns '\\r' are treated as s
 
 **Example:**
 
-The following statements will each return "This text has been stripped."::
+The following statements will each return "This text has been stripped.":
+
+.. code-block:: taggerscript
 
     $strip(This text has been stripped.)
     $strip(This text has been stripped.  )

--- a/functions/func_sub.rst
+++ b/functions/func_sub.rst
@@ -14,7 +14,9 @@ Returns an empty string if an argument is missing or not an integer.
 
 **Example:**
 
-The following statements will return the values indicated::
+The following statements will return the values indicated:
+
+.. code-block:: taggerscript
 
     $sub(20,15)      ==>  "5"
     $sub(20,-15)     ==>  "35"

--- a/functions/func_substr.rst
+++ b/functions/func_substr.rst
@@ -23,7 +23,9 @@ string.
 
 **Example:**
 
-The following statements will return the values indicated::
+The following statements will return the values indicated:
+
+.. code-block:: taggerscript
 
     $substr(abcdefg)        ==>  "abcdefg"
     $substr(abcdefg,3)      ==>  "defg"

--- a/functions/func_swapprefix.rst
+++ b/functions/func_swapprefix.rst
@@ -16,7 +16,9 @@ Note that the matching is case-sensitive.
 
 **Example:**
 
-If the ``albumartist`` is "Le Butcherettes", the following statements will return the values indicated::
+If the ``albumartist`` is "Le Butcherettes", the following statements will return the values indicated:
+
+.. code-block:: taggerscript
 
     $swapprefix(%albumartist%)               ==>  "Le Butcherettes"
     $swapprefix(%albumartist%,le)            ==>  "Le Butcherettes"

--- a/functions/func_truncate.rst
+++ b/functions/func_truncate.rst
@@ -17,7 +17,9 @@ than the number of characters in ``text``, the function will return an empty str
 
 **Example:**
 
-The following statements will return the values indicated::
+The following statements will return the values indicated:
+
+.. code-block:: taggerscript
 
     $truncate(Once upon a time,)     ==>  ""
     $truncate(Once upon a time,0)    ==>  ""

--- a/functions/func_unique.rst
+++ b/functions/func_unique.rst
@@ -24,7 +24,9 @@ missing ``$unique`` will return an empty string.
 
 **Example:**
 
-The following statements will return the values indicated::
+The following statements will return the values indicated:
+
+.. code-block:: taggerscript
 
     $setmulti(foo,a; A; B; b; cd; Cd; cD; CD; a; A; b)
     $set(bar,a; A; B; b; cd; Cd; cD; CD; a; A; b)

--- a/functions/func_unset.rst
+++ b/functions/func_unset.rst
@@ -14,6 +14,8 @@ Unsets the variable ``name``.  The function allows for wildcards to unset certai
 
 **Example:**
 
-The following would unset all performer tags::
+The following would unset all performer tags:
+
+.. code-block:: taggerscript
 
     $unset(performer:*)

--- a/functions/func_upper.rst
+++ b/functions/func_upper.rst
@@ -13,6 +13,8 @@ Returns ``text`` in upper case.
 
 **Example:**
 
-The following statement will return the value indicated::
+The following statement will return the value indicated:
+
+.. code-block:: taggerscript
 
     $upper(This text is UPPER case)  ==>  "THIS TEXT IS UPPER CASE"

--- a/functions/func_while.rst
+++ b/functions/func_while.rst
@@ -21,6 +21,8 @@ within the ``code`` script.
 
 **Example:**
 
-The following statement will set ``return`` to "Echo... echo... echo..."::
+The following statement will set ``return`` to "Echo... echo... echo...":
+
+.. code-block:: taggerscript
 
     $set(return,Echo...)$while($lt(%_loop_count%,2),$set(return,%return% echo...))

--- a/setup.py
+++ b/setup.py
@@ -144,6 +144,7 @@ IGNORE_ROLES = [
 
 RE_TEST_DIRECTIVE_1 = re.compile(r'^No directive entry for "([^"]+)')
 RE_TEST_DIRECTIVE_2 = re.compile(r'^.*directive type "([^"]+)".*$')
+RE_TEST_DIRECTIVE_3 = re.compile(r'^.*No Pygments lexer found for "taggerscript".*$')
 
 RE_TEST_ROLE_1 = re.compile(r'^No role entry for "([^"]+)')
 RE_TEST_ROLE_2 = re.compile(r'^.*role "([^"]+)".*$')
@@ -364,6 +365,12 @@ class LintRST():
                         err_process = err_process and not bool(m and m.group(1) in IGNORE_DIRECTIVES)
                         m = RE_TEST_ROLE_1.match(err.message)
                         err_process = err_process and not bool(m and m.group(1) in IGNORE_ROLES)
+                elif err.type == 'WARNING':
+                    if RE_TEST_DIRECTIVE_3.match(err.message):
+                        err.type = 'UNTESTED'
+                        self.print_error(err)
+                        err_processed = True
+                        break
                 elif err.type == 'ERROR' or err.type == 'SEVERE':
                     m = RE_TEST_DIRECTIVE_2.match(err.message)
                     err_process = err_process and not bool(m and m.group(1) in IGNORE_DIRECTIVES)

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ import restructuredtext_lint
 import conf
 import tag_mapping
 
+
 SCRIPT_NAME = 'Picard Docs Builder'
 SCRIPT_VERS = '0.14'
 SCRIPT_COPYRIGHT = '2020'
@@ -70,6 +71,8 @@ class SPHINX_():    # pylint: disable=too-few-public-methods
     }
 
 
+
+
 ######################
 #   Linter Options   #
 ######################
@@ -81,6 +84,7 @@ PYTHON_FILES_TO_CHECK = [
     'setup.py',
     'conf.py',
     'tag_mapping.py',
+    '_extensions/*.py',
 ]
 
 #################################################################

--- a/tutorials/naming_script.rst
+++ b/tutorials/naming_script.rst
@@ -15,23 +15,31 @@ that we will have one directory level for the album which will contain the songs
 First, let's have a look at what we need. You see a list of the available tags in the :doc:`../variables/tags_basic` section.
 We want the **ARTIST** name, so available tags for this could be ``albumartist`` or ``artist``. This should be the
 name for an album folder, so ``albumartist`` sounds like what we need. To get the actual value for a tag you need to enclose
-its name in percent signs. So let’s start::
+its name in percent signs. So let’s start:
+
+.. code-block:: taggerscript
 
    %albumartist%
 
 Now we want the **YEAR**. There is no ``year`` tag, but there is ``date``. Let’s use this for now. If we want to add
 extra text like the "**-**" just write it down. We need to be careful with the parentheses, because those are special
-variables in scripting. We need to prefix them with a backslash. Let’s add this all::
+variables in scripting. We need to prefix them with a backslash. Let’s add this all:
+
+.. code-block:: taggerscript
 
    %albumartist% - \(%date%\)
 
-Now we want the **ALBUM NAME**. That’s simple, just use ``album``::
+Now we want the **ALBUM NAME**. That’s simple, just use ``album``:
+
+.. code-block:: taggerscript
 
    %albumartist% - \(%date%\) %album%
 
 That takes care of the directory portion of the renaming.  The next part is the **TRACK** number and **SONG TITLE**.  The
 track number is available as ``tracknumber`` and the title of the track is simply ``title``.  Adding these to our script
-we get::
+we get:
+
+.. code-block:: taggerscript
 
    %albumartist% - \(%date%\) %album%/%tracknumber% - %title%
 
@@ -41,28 +49,38 @@ we get a full date instead of just the year. Finally, sometimes if you tag exist
 ``albumartist`` set, just ``artist``.
 
 Let’s fix the track number first. We can take care of that by using the ``$num()`` function to add a leading zero to the
-number shown for tracks 1 through 9::
+number shown for tracks 1 through 9:
+
+.. code-block:: taggerscript
 
    %albumartist% - \(%date%\) %album%/$num(%tracknumber%,2) - %title%
 
-Now let’s fix the **ARTIST**. We can fallback to using ``artist`` if ``albumartist`` is not available by using::
+Now let’s fix the **ARTIST**. We can fallback to using ``artist`` if ``albumartist`` is not available by using:
+
+.. code-block:: taggerscript
 
    $if2(%albumartist%,%artist%) - \(%date%\) %album%/$num(%tracknumber%,2) - %title%
 
 The ``$if2()`` function uses the first value that is not empty, so if ``albumartist`` is empty it uses ``artist`` instead.
 
 For the ``date`` tag the dates from MusicBrainz are always formatted as YYYY-MM-DD. We only need the year, so let’s get
-just the first 4 characters with the ``$left()`` function::
+just the first 4 characters with the ``$left()`` function:
+
+.. code-block:: taggerscript
 
    $if2(%albumartist%,%artist%) - \($left(%date%,4)\) %album%/$num(%tracknumber%,2) - %title%
 
 What happens if there is no ``date`` tag information? Sometimes MusicBrainz does not have the release date of an album
 set as it is not yet known or hasn't been entered into the database. It would be great to omit the entire date with the
-parentheses in this case. Let’s use the ``$if()`` function to check whether the date is set::
+parentheses in this case. Let’s use the ``$if()`` function to check whether the date is set:
+
+.. code-block:: taggerscript
 
    $if2(%albumartist%,%artist%) - $if(%date%,\($left(%date%,4)\) )%album%/$num(%tracknumber%,2) - %title%
 
-Alternately, we can enter a placeholder such a "**0000**" if the date is missing::
+Alternately, we can enter a placeholder such a "**0000**" if the date is missing:
+
+.. code-block:: taggerscript
 
    $if2(%albumartist%,%artist%) - \($if(%date%,$left(%date%,4),0000)\) %album%/$num(%tracknumber%,2) - %title%
 


### PR DESCRIPTION
<!--
    Thank-you for submitting a pull request. Your effort and input is appreciated.

    Please use this template to help us review your change. Not everything is
    required for every change, so please feel free to omit any sections that
    are not relevant to your change.

    Also, please ensure that you've reviewed the guidelines in CONTRIBUTING.md.
-->

### Summary

This is a…

- [ ] Correction
- [x] Addition
- [ ] Restructuring
- [ ] Minor / simple change (like a typo)
- [ ] Other

### Reason for the Change

Provide syntax highlighting for Picard Tagger Script in code examples.


### Description of the Change

- Add a Sphinx extension that registers a custom Pygments lexer for the Tagger Script syntax
- Add a stylesheet to highlight taggerscript with the same colors as Picard does
- Mark all code blocks explicitly for taggerscript