### PR TITLE
Allow cross linking to scripting functions with :ref:`func_{name}`

### DIFF
--- a/extending/scripts.rst
+++ b/extending/scripts.rst
@@ -93,7 +93,7 @@ as the primary date in your file's tags you could use the following script:
 
    $set(date,$if2(%originaldate%,%date%))
 
-The use of ``$if2()`` ensures that if ``originaldate`` is empty it will fall back to ``date``.
+The use of :ref:`func_if2` ensures that if ``originaldate`` is empty it will fall back to ``date``.
 
 In addition Picard provides a variable ``%_recording_firstreleasedate%``, which tries to provide
 the first release date per recording (which can be different for each track in a release).

--- a/functions/func_add.rst
+++ b/functions/func_add.rst
@@ -1,5 +1,7 @@
 .. MusicBrainz Picard Documentation Project
 
+.. _func_add:
+
 $add
 ====
 

--- a/functions/func_and.rst
+++ b/functions/func_and.rst
@@ -1,5 +1,7 @@
 .. MusicBrainz Picard Documentation Project
 
+.. _func_and:
+
 $and
 ====
 

--- a/functions/func_copy.rst
+++ b/functions/func_copy.rst
@@ -1,5 +1,7 @@
 .. MusicBrainz Picard Documentation Project
 
+.. _func_copy:
+
 $copy
 =====
 

--- a/functions/func_copymerge.rst
+++ b/functions/func_copymerge.rst
@@ -1,5 +1,7 @@
 .. MusicBrainz Picard Documentation Project
 
+.. _func_copymerge:
+
 $copymerge
 ==========
 
@@ -10,7 +12,7 @@ $copymerge
 **Description:**
 
 Merges metadata from variable ``source`` into ``target``, removing duplicates and appending to the end,
-so retaining the original ordering. Like ``$copy``, this will also copy multi-valued variables
+so retaining the original ordering. Like :ref:`func_copy`, this will also copy multi-valued variables
 without flattening them.  Following the operation, ``target`` will be a multi-value variable.
 
 Note that the variable names for ``target`` and ``source`` are passed directly without enclosing them

--- a/functions/func_datetime.rst
+++ b/functions/func_datetime.rst
@@ -1,5 +1,7 @@
 .. MusicBrainz Picard Documentation Project
 
+.. _func_datetime:
+
 $datetime
 =========
 

--- a/functions/func_delete.rst
+++ b/functions/func_delete.rst
@@ -1,5 +1,7 @@
 .. MusicBrainz Picard Documentation Project
 
+.. _func_delete:
+
 $delete
 =======
 

--- a/functions/func_delprefix.rst
+++ b/functions/func_delprefix.rst
@@ -1,5 +1,7 @@
 .. MusicBrainz Picard Documentation Project
 
+.. _func_delprefix:
+
 $delprefix
 ==========
 

--- a/functions/func_div.rst
+++ b/functions/func_div.rst
@@ -1,5 +1,7 @@
 .. MusicBrainz Picard Documentation Project
 
+.. _func_div:
+
 $div
 ====
 

--- a/functions/func_endswith.rst
+++ b/functions/func_endswith.rst
@@ -1,5 +1,7 @@
 .. MusicBrainz Picard Documentation Project
 
+.. _func_endswith:
+
 $endswith
 =========
 

--- a/functions/func_eq.rst
+++ b/functions/func_eq.rst
@@ -1,5 +1,7 @@
 .. MusicBrainz Picard Documentation Project
 
+.. _func_eq:
+
 $eq
 ===
 

--- a/functions/func_eq_all.rst
+++ b/functions/func_eq_all.rst
@@ -1,5 +1,7 @@
 .. MusicBrainz Picard Documentation Project
 
+.. _func_eq_all:
+
 $eq_all
 =======
 

--- a/functions/func_eq_any.rst
+++ b/functions/func_eq_any.rst
@@ -1,5 +1,7 @@
 .. MusicBrainz Picard Documentation Project
 
+.. _func_eq_any:
+
 $eq_any
 =======
 

--- a/functions/func_find.rst
+++ b/functions/func_find.rst
@@ -18,7 +18,7 @@ support wildcards.
 
 .. note::
 
-    Prior to Picard 2.3.2 :ref:`func_find` returned "-1" if ``needle`` was not found.
+    Prior to Picard 2.3.2 ``$find`` returned "-1" if ``needle`` was not found.
 
 
 **Example:**

--- a/functions/func_find.rst
+++ b/functions/func_find.rst
@@ -1,5 +1,7 @@
 .. MusicBrainz Picard Documentation Project
 
+.. _func_find:
+
 $find
 =====
 
@@ -16,7 +18,7 @@ support wildcards.
 
 .. note::
 
-    Prior to Picard 2.3.2 ``$find`` returned "-1" if ``needle`` was not found.
+    Prior to Picard 2.3.2 :ref:`func_find` returned "-1" if ``needle`` was not found.
 
 
 **Example:**

--- a/functions/func_firstalphachar.rst
+++ b/functions/func_firstalphachar.rst
@@ -1,5 +1,7 @@
 .. MusicBrainz Picard Documentation Project
 
+.. _func_firstalphachar:
+
 $firstalphachar
 ===============
 

--- a/functions/func_firstwords.rst
+++ b/functions/func_firstwords.rst
@@ -1,5 +1,7 @@
 .. MusicBrainz Picard Documentation Project
 
+.. _func_firstwords:
+
 $firstwords
 ===========
 

--- a/functions/func_foreach.rst
+++ b/functions/func_foreach.rst
@@ -1,5 +1,7 @@
 .. MusicBrainz Picard Documentation Project
 
+.. _func_foreach:
+
 $foreach
 ========
 

--- a/functions/func_get.rst
+++ b/functions/func_get.rst
@@ -1,5 +1,7 @@
 .. MusicBrainz Picard Documentation Project
 
+.. _func_get:
+
 $get
 ====
 

--- a/functions/func_getmulti.rst
+++ b/functions/func_getmulti.rst
@@ -1,5 +1,7 @@
 .. MusicBrainz Picard Documentation Project
 
+.. _func_getmulti:
+
 $getmulti
 =========
 

--- a/functions/func_gt.rst
+++ b/functions/func_gt.rst
@@ -1,5 +1,7 @@
 .. MusicBrainz Picard Documentation Project
 
+.. _func_gt:
+
 $gt
 ===
 

--- a/functions/func_gte.rst
+++ b/functions/func_gte.rst
@@ -1,5 +1,7 @@
 .. MusicBrainz Picard Documentation Project
 
+.. _func_gte:
+
 $gte
 ====
 

--- a/functions/func_if.rst
+++ b/functions/func_if.rst
@@ -1,5 +1,7 @@
 .. MusicBrainz Picard Documentation Project
 
+.. _func_if:
+
 $if
 ===
 

--- a/functions/func_if2.rst
+++ b/functions/func_if2.rst
@@ -1,5 +1,7 @@
 .. MusicBrainz Picard Documentation Project
 
+.. _func_if2:
+
 $if2
 ====
 

--- a/functions/func_in.rst
+++ b/functions/func_in.rst
@@ -1,5 +1,7 @@
 .. MusicBrainz Picard Documentation Project
 
+.. _func_in:
+
 $in
 ===
 

--- a/functions/func_initials.rst
+++ b/functions/func_initials.rst
@@ -1,5 +1,7 @@
 .. MusicBrainz Picard Documentation Project
 
+.. _func_initials:
+
 $initials
 =========
 

--- a/functions/func_inmulti.rst
+++ b/functions/func_inmulti.rst
@@ -1,5 +1,7 @@
 .. MusicBrainz Picard Documentation Project
 
+.. _func_inmulti:
+
 $inmulti
 ========
 

--- a/functions/func_is_audio.rst
+++ b/functions/func_is_audio.rst
@@ -1,5 +1,7 @@
 .. MusicBrainz Picard Documentation Project
 
+.. _func_is_audio:
+
 $is_audio
 =========
 

--- a/functions/func_is_complete.rst
+++ b/functions/func_is_complete.rst
@@ -1,5 +1,7 @@
 .. MusicBrainz Picard Documentation Project
 
+.. _func_is_complete:
+
 $is_complete
 ============
 

--- a/functions/func_is_video.rst
+++ b/functions/func_is_video.rst
@@ -1,5 +1,7 @@
 .. MusicBrainz Picard Documentation Project
 
+.. _func_is_video:
+
 $is_video
 =========
 

--- a/functions/func_join.rst
+++ b/functions/func_join.rst
@@ -1,5 +1,7 @@
 .. MusicBrainz Picard Documentation Project
 
+.. _func_join:
+
 $join
 =====
 

--- a/functions/func_left.rst
+++ b/functions/func_left.rst
@@ -1,5 +1,7 @@
 .. MusicBrainz Picard Documentation Project
 
+.. _func_left:
+
 $left
 =====
 

--- a/functions/func_len.rst
+++ b/functions/func_len.rst
@@ -1,5 +1,7 @@
 .. MusicBrainz Picard Documentation Project
 
+.. _func_len:
+
 $len
 ====
 

--- a/functions/func_lenmulti.rst
+++ b/functions/func_lenmulti.rst
@@ -1,5 +1,7 @@
 .. MusicBrainz Picard Documentation Project
 
+.. _func_lenmulti:
+
 $lenmulti
 =========
 
@@ -11,7 +13,7 @@ $lenmulti
 Returns the number of elements in the multi-value variable ``name``. A literal value
 representing a multi-value can be substituted for ``name``, using the ``separator``
 (or a semicolon followed by a space "; " if not passed) to coerce the value into a
-proper multi-valued variable.  If ``name`` is missing ``$lenmulti`` will return "0".  If
+proper multi-valued variable.  If ``name`` is missing :ref:`func_lenmulti` will return "0".  If
 ``separator`` is specified but left blank (e.g. ``$setmulti(A; B; C,)``) the function
 will return "1".
 

--- a/functions/func_lenmulti.rst
+++ b/functions/func_lenmulti.rst
@@ -13,7 +13,7 @@ $lenmulti
 Returns the number of elements in the multi-value variable ``name``. A literal value
 representing a multi-value can be substituted for ``name``, using the ``separator``
 (or a semicolon followed by a space "; " if not passed) to coerce the value into a
-proper multi-valued variable.  If ``name`` is missing :ref:`func_lenmulti` will return "0".  If
+proper multi-valued variable.  If ``name`` is missing ``$lenmulti`` will return "0".  If
 ``separator`` is specified but left blank (e.g. ``$setmulti(A; B; C,)``) the function
 will return "1".
 

--- a/functions/func_lower.rst
+++ b/functions/func_lower.rst
@@ -1,5 +1,7 @@
 .. MusicBrainz Picard Documentation Project
 
+.. _func_lower:
+
 $lower
 ======
 

--- a/functions/func_lt.rst
+++ b/functions/func_lt.rst
@@ -1,5 +1,7 @@
 .. MusicBrainz Picard Documentation Project
 
+.. _func_lt:
+
 $lt
 ===
 

--- a/functions/func_lte.rst
+++ b/functions/func_lte.rst
@@ -1,5 +1,7 @@
 .. MusicBrainz Picard Documentation Project
 
+.. _func_lte:
+
 $lte
 ====
 

--- a/functions/func_map.rst
+++ b/functions/func_map.rst
@@ -1,5 +1,7 @@
 .. MusicBrainz Picard Documentation Project
 
+.. _func_map:
+
 $map
 ====
 
@@ -58,7 +60,7 @@ Empty elements are automatically removed from the output.
     The following statements will return the values indicated:
 
     .. code-block:: taggerscript
- 
+
        $set(foo,First:A; Second:B)
        $map(%foo%,
            $upper(%_loop_count%=%_loop_value%))    ==>  "1=FIRST:A; SECOND:B"

--- a/functions/func_matchedtracks.rst
+++ b/functions/func_matchedtracks.rst
@@ -1,5 +1,7 @@
 .. MusicBrainz Picard Documentation Project
 
+.. _func_matchedtracks:
+
 $matchedtracks
 ==============
 

--- a/functions/func_mod.rst
+++ b/functions/func_mod.rst
@@ -1,5 +1,7 @@
 .. MusicBrainz Picard Documentation Project
 
+.. _func_mod:
+
 $mod
 ====
 

--- a/functions/func_mul.rst
+++ b/functions/func_mul.rst
@@ -1,5 +1,7 @@
 .. MusicBrainz Picard Documentation Project
 
+.. _func_mul:
+
 $mul
 ====
 

--- a/functions/func_ne.rst
+++ b/functions/func_ne.rst
@@ -1,5 +1,7 @@
 .. MusicBrainz Picard Documentation Project
 
+.. _func_ne:
+
 $ne
 ===
 

--- a/functions/func_ne_all.rst
+++ b/functions/func_ne_all.rst
@@ -1,5 +1,7 @@
 .. MusicBrainz Picard Documentation Project
 
+.. _func_ne_all:
+
 $ne_all
 =======
 

--- a/functions/func_ne_any.rst
+++ b/functions/func_ne_any.rst
@@ -1,5 +1,7 @@
 .. MusicBrainz Picard Documentation Project
 
+.. _func_ne_any:
+
 $ne_any
 =======
 

--- a/functions/func_noop.rst
+++ b/functions/func_noop.rst
@@ -1,5 +1,7 @@
 .. MusicBrainz Picard Documentation Project
 
+.. _func_noop:
+
 $noop
 =====
 

--- a/functions/func_not.rst
+++ b/functions/func_not.rst
@@ -1,5 +1,7 @@
 .. MusicBrainz Picard Documentation Project
 
+.. _func_not:
+
 $not
 ====
 

--- a/functions/func_num.rst
+++ b/functions/func_num.rst
@@ -1,5 +1,7 @@
 .. MusicBrainz Picard Documentation Project
 
+.. _func_num:
+
 $num
 ====
 

--- a/functions/func_or.rst
+++ b/functions/func_or.rst
@@ -1,5 +1,7 @@
 .. MusicBrainz Picard Documentation Project
 
+.. _func_or:
+
 $or
 ===
 

--- a/functions/func_pad.rst
+++ b/functions/func_pad.rst
@@ -1,5 +1,7 @@
 .. MusicBrainz Picard Documentation Project
 
+.. _func_pad:
+
 $pad
 ====
 

--- a/functions/func_performer.rst
+++ b/functions/func_performer.rst
@@ -1,5 +1,7 @@
 .. MusicBrainz Picard Documentation Project
 
+.. _func_performer:
+
 $performer
 ==========
 

--- a/functions/func_replace.rst
+++ b/functions/func_replace.rst
@@ -1,5 +1,7 @@
 .. MusicBrainz Picard Documentation Project
 
+.. _func_replace:
+
 $replace
 ========
 

--- a/functions/func_replacemulti.rst
+++ b/functions/func_replacemulti.rst
@@ -1,5 +1,7 @@
 .. MusicBrainz Picard Documentation Project
 
+.. _func_replacemulti:
+
 $replacemulti
 =============
 

--- a/functions/func_reverse.rst
+++ b/functions/func_reverse.rst
@@ -1,5 +1,7 @@
 .. MusicBrainz Picard Documentation Project
 
+.. _func_reverse:
+
 $reverse
 ========
 

--- a/functions/func_reversemulti.rst
+++ b/functions/func_reversemulti.rst
@@ -1,5 +1,7 @@
 .. MusicBrainz Picard Documentation Project
 
+.. _func_reversemulti:
+
 $reversemulti
 =============
 
@@ -14,7 +16,7 @@ value representing a multi-value can be substituted for ``name``, using the ``se
 semicolon followed by a space "; " if not passed) to coerce the value into a proper multi-valued
 variable.
 
-This function can be used in conjunction with the ``$sortmulti`` function to sort in descending order.
+This function can be used in conjunction with the :ref:`func_sortmulti` function to sort in descending order.
 
 
 **Example:**

--- a/functions/func_right.rst
+++ b/functions/func_right.rst
@@ -1,5 +1,7 @@
 .. MusicBrainz Picard Documentation Project
 
+.. _func_right:
+
 $right
 ======
 

--- a/functions/func_rreplace.rst
+++ b/functions/func_rreplace.rst
@@ -1,5 +1,7 @@
 .. MusicBrainz Picard Documentation Project
 
+.. _func_rreplace:
+
 $rreplace
 =========
 

--- a/functions/func_rsearch.rst
+++ b/functions/func_rsearch.rst
@@ -1,5 +1,7 @@
 .. MusicBrainz Picard Documentation Project
 
+.. _func_rsearch:
+
 $rsearch
 ========
 

--- a/functions/func_set.rst
+++ b/functions/func_set.rst
@@ -1,5 +1,7 @@
 .. MusicBrainz Picard Documentation Project
 
+.. _func_set:
+
 $set
 ====
 

--- a/functions/func_setmulti.rst
+++ b/functions/func_setmulti.rst
@@ -1,5 +1,7 @@
 .. MusicBrainz Picard Documentation Project
 
+.. _func_setmulti:
+
 $setmulti
 =========
 

--- a/functions/func_slice.rst
+++ b/functions/func_slice.rst
@@ -1,5 +1,7 @@
 .. MusicBrainz Picard Documentation Project
 
+.. _func_slice:
+
 $slice
 ======
 

--- a/functions/func_sortmulti.rst
+++ b/functions/func_sortmulti.rst
@@ -15,7 +15,7 @@ Returns a copy of the multi-value variable ``name`` with the elements sorted in 
 order. A literal value representing a multi-value can be substituted for ``name``,
 using the ``separator`` (or a semicolon followed by a space "; " if not passed) to
 coerce the value into a proper multi-valued variable.  If ``name`` is missing
-:ref:`func_sortmulti` will return an empty string.
+``$sortmulti`` will return an empty string.
 
 
 **Example:**

--- a/functions/func_sortmulti.rst
+++ b/functions/func_sortmulti.rst
@@ -1,5 +1,7 @@
 .. MusicBrainz Picard Documentation Project
 
+.. _func_sortmulti:
+
 $sortmulti
 ==========
 
@@ -13,7 +15,7 @@ Returns a copy of the multi-value variable ``name`` with the elements sorted in 
 order. A literal value representing a multi-value can be substituted for ``name``,
 using the ``separator`` (or a semicolon followed by a space "; " if not passed) to
 coerce the value into a proper multi-valued variable.  If ``name`` is missing
-``$sortmulti`` will return an empty string.
+:ref:`func_sortmulti` will return an empty string.
 
 
 **Example:**

--- a/functions/func_startswith.rst
+++ b/functions/func_startswith.rst
@@ -1,5 +1,7 @@
 .. MusicBrainz Picard Documentation Project
 
+.. _func_startswith:
+
 $startswith
 ===========
 

--- a/functions/func_strip.rst
+++ b/functions/func_strip.rst
@@ -1,5 +1,7 @@
 .. MusicBrainz Picard Documentation Project
 
+.. _func_strip:
+
 $strip
 ======
 

--- a/functions/func_sub.rst
+++ b/functions/func_sub.rst
@@ -1,5 +1,7 @@
 .. MusicBrainz Picard Documentation Project
 
+.. _func_sub:
+
 $sub
 ====
 

--- a/functions/func_substr.rst
+++ b/functions/func_substr.rst
@@ -1,5 +1,7 @@
 .. MusicBrainz Picard Documentation Project
 
+.. _func_substr:
+
 $substr
 =======
 

--- a/functions/func_swapprefix.rst
+++ b/functions/func_swapprefix.rst
@@ -1,5 +1,7 @@
 .. MusicBrainz Picard Documentation Project
 
+.. _func_swapprefix:
+
 $swapprefix
 ===========
 

--- a/functions/func_title.rst
+++ b/functions/func_title.rst
@@ -1,5 +1,7 @@
 .. MusicBrainz Picard Documentation Project
 
+.. _func_title:
+
 $title
 ======
 

--- a/functions/func_trim.rst
+++ b/functions/func_trim.rst
@@ -1,5 +1,7 @@
 .. MusicBrainz Picard Documentation Project
 
+.. _func_trim:
+
 $trim
 =====
 

--- a/functions/func_truncate.rst
+++ b/functions/func_truncate.rst
@@ -1,5 +1,7 @@
 .. MusicBrainz Picard Documentation Project
 
+.. _func_truncate:
+
 $truncate
 =========
 

--- a/functions/func_unique.rst
+++ b/functions/func_unique.rst
@@ -1,5 +1,7 @@
 .. MusicBrainz Picard Documentation Project
 
+.. _func_unique:
+
 $unique
 ==========
 
@@ -14,7 +16,7 @@ By default, the comparison ignores the case of the elements; however, this can b
 setting ``case_sensitive`` to a non-empty value. A literal value representing a multi-value
 can be substituted for ``name``, using the ``separator`` (or a semicolon followed by a space
 "; " if not passed) to coerce the value into a proper multi-valued variable.  If ``name`` is
-missing ``$unique`` will return an empty string.
+missing :ref:`func_unique` will return an empty string.
 
 .. note::
 

--- a/functions/func_unique.rst
+++ b/functions/func_unique.rst
@@ -16,7 +16,7 @@ By default, the comparison ignores the case of the elements; however, this can b
 setting ``case_sensitive`` to a non-empty value. A literal value representing a multi-value
 can be substituted for ``name``, using the ``separator`` (or a semicolon followed by a space
 "; " if not passed) to coerce the value into a proper multi-valued variable.  If ``name`` is
-missing :ref:`func_unique` will return an empty string.
+missing ``$unique`` will return an empty string.
 
 .. note::
 

--- a/functions/func_unset.rst
+++ b/functions/func_unset.rst
@@ -1,5 +1,7 @@
 .. MusicBrainz Picard Documentation Project
 
+.. _func_unset:
+
 $unset
 ======
 

--- a/functions/func_upper.rst
+++ b/functions/func_upper.rst
@@ -1,5 +1,7 @@
 .. MusicBrainz Picard Documentation Project
 
+.. _func_upper:
+
 $upper
 ======
 

--- a/functions/func_while.rst
+++ b/functions/func_while.rst
@@ -1,5 +1,7 @@
 .. MusicBrainz Picard Documentation Project
 
+.. _func_while:
+
 $while
 ======
 

--- a/tutorials/naming_script.rst
+++ b/tutorials/naming_script.rst
@@ -48,7 +48,7 @@ reasons.  What if there are 10 or more tracks on the album and they don't sort p
 we get a full date instead of just the year. Finally, sometimes if you tag existing files they might not have the
 ``albumartist`` set, just ``artist``.
 
-Let’s fix the track number first. We can take care of that by using the ``$num()`` function to add a leading zero to the
+Let’s fix the track number first. We can take care of that by using the :ref:`func_num` function to add a leading zero to the
 number shown for tracks 1 through 9:
 
 .. code-block:: taggerscript
@@ -61,10 +61,10 @@ Now let’s fix the **ARTIST**. We can fallback to using ``artist`` if ``albumar
 
    $if2(%albumartist%,%artist%) - \(%date%\) %album%/$num(%tracknumber%,2) - %title%
 
-The ``$if2()`` function uses the first value that is not empty, so if ``albumartist`` is empty it uses ``artist`` instead.
+The :ref:`func_if2` function uses the first value that is not empty, so if ``albumartist`` is empty it uses ``artist`` instead.
 
 For the ``date`` tag the dates from MusicBrainz are always formatted as YYYY-MM-DD. We only need the year, so let’s get
-just the first 4 characters with the ``$left()`` function:
+just the first 4 characters with the :ref:`func_left` function:
 
 .. code-block:: taggerscript
 
@@ -72,7 +72,7 @@ just the first 4 characters with the ``$left()`` function:
 
 What happens if there is no ``date`` tag information? Sometimes MusicBrainz does not have the release date of an album
 set as it is not yet known or hasn't been entered into the database. It would be great to omit the entire date with the
-parentheses in this case. Let’s use the ``$if()`` function to check whether the date is set:
+parentheses in this case. Let’s use the :ref:`func_if` function to check whether the date is set:
 
 .. code-block:: taggerscript
 

--- a/variables/variables_advanced.rst
+++ b/variables/variables_advanced.rst
@@ -15,7 +15,7 @@ If you enable tagging with :ref:`Advanced Relationships <advanced_relationships>
 
 **_performance_attributes**
 
-    List of performance attributes for the work (e.g.: "live", "cover", "medley"). Use ``$inmulti`` to check for
+    List of performance attributes for the work (e.g.: "live", "cover", "medley"). Use :ref:`func_inmulti` to check for
     a specific type (i.e.: ``$if($inmulti(%_performance_attributes%,medley), (Medley),)``). (*since Picard 1.3*)
 
 **_recordingcomment**


### PR DESCRIPTION
<!--
    Thank-you for submitting a pull request. Your effort and input is appreciated.

    Please use this template to help us review your change. Not everything is
    required for every change, so please feel free to omit any sections that
    are not relevant to your change.

    Also, please ensure that you've reviewed the guidelines in CONTRIBUTING.md.
-->

### Summary

This is a…

- [ ] Correction
- [x] Addition
- [ ] Restructuring
- [ ] Minor / simple change (like a typo)
- [ ] Other

### Reason for the Change

Various places in the documentation mention specific scripting functions. It should be possible to easily cross reference those to the function's documentation.

### Description of the Change

Add `func_{name}` targets to all function documentations, allowing them to be referenced with e.g. :ref:\`func_is_complete\`

### Additional Action Required

Something similar would be great for variables as well, but I'm unsure how to best do this without adding to much redundancy. A completely separate section per variable seems to much. So for now I restricted this to functions only.
