### PR TITLE
Multiple release country tutorial

### DIFF
--- a/_locale/fr/LC_MESSAGES/tutorials/multiple_release_countries.po
+++ b/_locale/fr/LC_MESSAGES/tutorials/multiple_release_countries.po
@@ -1,0 +1,177 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) This documentation is licensed under CC0 1.0.
+# This file is distributed under the same license as the MusicBrainz Picard
+# package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, 2021.
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: MusicBrainz Picard v2.6.2\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2021-05-30 09:50-0600\n"
+"PO-Revision-Date: 2021-05-30 10:05-0600\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Generated-By: Babel 2.9.1\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+"Last-Translator: Bob Swift <bswift@rsds.ca>\n"
+"Language-Team: \n"
+"Language: fr\n"
+"X-Generator: Poedit 2.4.3\n"
+
+#: ../../tutorials/multiple_release_countries.rst:4
+msgid ""
+"Handling of :index:`multiple release countries <multiple release "
+"countries, release countries; multiple>`"
+msgstr ""
+"Gestion de :index:`plusieurs pays de sortie <plusieurs pays de sortie, "
+"pays de sortie; plusieurs>`."
+
+#: ../../tutorials/multiple_release_countries.rst:8
+msgid ""
+"Some releases, especially digital releases, can have a very long list of "
+"release countries, sometimes listing all of the world's countries except "
+"for a few where the release is not officially available. Picard offers "
+"some tools to handle this."
+msgstr ""
+"Certaines sorties, en particulier les sorties numériques, peuvent avoir "
+"une très longue liste de pays de sortie, listant parfois tous les pays "
+"du monde sauf quelques-uns où la sortie n'est pas officiellement "
+"disponible. Picard propose quelques outils pour gérer cela."
+
+#: ../../tutorials/multiple_release_countries.rst:11
+msgid ""
+"Let’s take the release **Bleach**, by Nirvana (MusicBrainz release "
+"`adab3feb-1822-4d27-a997-db7d6c9688c0 <https://musicbrainz.org/release/"
+"adab3feb-1822-4d27-a997-db7d6c9688c0>`_) as an example."
+msgstr ""
+"Prenons l'exemple de **Bleach**, de Nirvana (MusicBrainz release "
+"`adab3feb-1822-4d27-a997-db7d6c9688c0 <https://musicbrainz.org/release/"
+"adab3feb-1822-4d27-a997-db7d6c9688c0>`_)."
+
+#: ../../tutorials/multiple_release_countries.rst:14
+msgid ""
+"By default Picard will write a single ``releasecountry`` tag to the "
+"files. Prior to v2.3.1, Picard had been populating the tag with what the "
+"MusicBrainz server returned as the country for the release. If there "
+"were multiple release events, this country field was just filled with "
+"the first one in alphabetical order (Afghanistan in our example). Picard "
+"v2.3.1 introduced some options to better handle this."
+msgstr ""
+"Par défaut, Picard écrit une seule balise ``releasecountry`` dans les "
+"fichiers. Avant la v2.3.1, Picard remplissait cette balise avec ce que "
+"le serveur MusicBrainz retournait comme pays pour la sortie. S'il y "
+"avait plusieurs sorties, ce champ pays était simplement rempli avec le "
+"premier par ordre alphabétique (Afghanistan dans notre exemple). Picard "
+"v2.3.1 a introduit quelques options pour mieux gérer ce problème."
+
+#: ../../tutorials/multiple_release_countries.rst:20
+msgid "Using preferred release countries"
+msgstr "Utilisation des pays de diffusion préférés"
+
+#: ../../tutorials/multiple_release_countries.rst:22
+msgid ""
+"If you configure preferred release countries in :menuselection:`"
+"\"Options --> Metadata --> Preferred Releases\"`. Picard will use the "
+"first country from the preferred release countries that is also in the "
+"list of release events. So if you have configured preferred release "
+"countries to be Europe, Canada, Germany and UK, for our example that "
+"would mean the ``releasecountry`` tag gets set to Canada."
+msgstr ""
+"Si vous configurez les pays de publication préférés dans :menuselection:`"
+"\"Options --> Metadata --> Preferred Releases\"`. Picard utilisera le "
+"premier pays de la liste des pays de diffusion préférés qui se trouve "
+"également dans la liste des événements de diffusion. Ainsi, si vous avez "
+"configuré les pays de diffusion préférés comme étant l'Europe, le "
+"Canada, l'Allemagne et le Royaume-Uni, dans notre exemple, cela signifie "
+"que la balise ``releasecountry`` sera définie sur le Canada."
+
+#: ../../tutorials/multiple_release_countries.rst:28
+msgid "Using scripting to set a different country"
+msgstr "Utilisation de scripts pour définir un pays différent"
+
+#: ../../tutorials/multiple_release_countries.rst:30
+msgid ""
+"Picard v2.3.1 also added a new variable ``%_releasecountries%``, which "
+"provides the complete list of release countries for a release as a multi-"
+"value variable. You can use this to set different values for the "
+"``releasecountry`` tag."
+msgstr ""
+"Picard v2.3.1 a également ajouté une nouvelle variable ``"
+"%_releasecountries%``, qui fournit la liste complète des pays de "
+"diffusion d'une version sous la forme d'une variable à plusieurs "
+"valeurs. Vous pouvez l'utiliser pour définir différentes valeurs pour la "
+"balise ``releasecountry``."
+
+#: ../../tutorials/multiple_release_countries.rst:33
+msgid ""
+"For example, the following script would set it to \"\\[International"
+"\\]\" if there are 10 or more release countries:"
+msgstr ""
+"Par exemple, le script suivant lui attribue la valeur \"\\[International"
+"\\]\" s'il y a 10 pays de diffusion ou plus:"
+
+#: ../../tutorials/multiple_release_countries.rst:39
+msgid ""
+"Of course you can adjust the count and the replacement text to your "
+"liking. You can also choose to save the entire list instead of just a "
+"single country to this tag using the script:"
+msgstr ""
+"Bien entendu, vous pouvez ajuster le nombre de pays et le texte de "
+"remplacement à votre convenance. Vous pouvez également choisir "
+"d'enregistrer la liste entière au lieu d'un seul pays dans cette balise "
+"en utilisant le script:"
+
+#: ../../tutorials/multiple_release_countries.rst:46
+msgid ""
+"Perhaps you prefer to limit this list to the first few entries. The "
+"following example just uses the first 6 countries:"
+msgstr ""
+"Vous préférez peut-être limiter cette liste aux premières entrées. "
+"L'exemple suivant utilise uniquement les 6 premiers pays:"
+
+#: ../../tutorials/multiple_release_countries.rst:54
+msgid "What’s missing?"
+msgstr "Qu'est-ce qui manque?"
+
+#: ../../tutorials/multiple_release_countries.rst:56
+msgid ""
+"Countries are currently written to the tags as their ISO 3166-1 country "
+"code, with some special values added for historical countries and things "
+"like \\[Europe\\] or \\[Worldwide\\]. These codes are not always easily "
+"recognizable or obvious, such as \"DZ\" for Algeria or \"DE\" for "
+"Germany. You can of course use scripting to make these more readable.  "
+"For example, if you want to see \"United Kingdom\" instead of \"GB\" in "
+"this tag use:"
+msgstr ""
+"Les pays sont actuellement inscrits dans les balises sous leur code pays "
+"ISO 3166-1, avec quelques valeurs spéciales ajoutées pour les pays "
+"historiques et des choses comme \\[Europe\\] ou \\[Worldwide\\]. Ces "
+"codes ne sont pas toujours facilement reconnaissables ou évidents, comme "
+"\"DZ\" pour l'Algérie ou \"DE\" pour l'Allemagne. Vous pouvez bien sûr "
+"utiliser des scripts pour les rendre plus lisibles.  Par exemple, si "
+"vous voulez voir \"United Kingdom\" au lieu de \"GB\" dans cette balise, "
+"utilisez:"
+
+#: ../../tutorials/multiple_release_countries.rst:64
+msgid ""
+"This might work if you deal only with a couple of countries in your "
+"collection, or you just want to handle some special cases like using "
+"\"Europe\" instead of \"XE\" such as in the following script:"
+msgstr ""
+"Cela peut fonctionner si vous ne traitez que quelques pays dans votre "
+"collection, ou si vous voulez simplement gérer certains cas particuliers "
+"comme l'utilisation de \"Europe\" au lieu de \"XE\", comme dans le "
+"script suivant:"
+
+#: ../../tutorials/multiple_release_countries.rst:74
+msgid ""
+"A change has been submitted to Picard to add a ``$countryname()`` "
+"function to easily convert the code into a readable name; however this "
+"is not scheduled for release until Picard v2.7."
+msgstr ""
+"Un changement a été soumis à Picard pour ajouter une fonction ``"
+"$countryname()`` afin de convertir facilement le code en un nom "
+"lisible ; cependant, cette fonction n'est pas prévue avant la version "
+"2.7 de Picard."

--- a/_locale/fr/LC_MESSAGES/variables/variables_basic.po
+++ b/_locale/fr/LC_MESSAGES/variables/variables_basic.po
@@ -8,8 +8,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: MusicBrainz Picard v2.3.2\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-02-22 09:40-0700\n"
-"PO-Revision-Date: 2021-02-22 09:43-0700\n"
+"POT-Creation-Date: 2021-05-30 09:50-0600\n"
+"PO-Revision-Date: 2021-05-30 09:54-0600\n"
 "Last-Translator: Bob Swift <bswift@rsds.ca>\n"
 "Language: fr\n"
 "Language-Team: \n"
@@ -17,8 +17,8 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Generated-By: Babel 2.8.0\n"
-"X-Generator: Poedit 2.4.2\n"
+"Generated-By: Babel 2.9.1\n"
+"X-Generator: Poedit 2.4.3\n"
 
 #: ../../variables/variables_basic.rst:8
 msgid ":index:`Basic Variables <variables; basic>`"
@@ -183,10 +183,22 @@ msgid "Release disambiguation comment. (*since Picard 0.15*)"
 msgstr "Le commentaire d'homonymie pour la version. (*depuis Picard 0,15*)"
 
 #: ../../variables/variables_basic.rst:71
+msgid "**_releasecountries**"
+msgstr "**_releasecountries**"
+
+#: ../../variables/variables_basic.rst:73
+msgid ""
+"This provides the complete list of release countries for the release as a multi-"
+"value variable. (*since Picard 2.3.1*)"
+msgstr ""
+"Ceci fournit la liste complète des pays de la version pour la version comme une "
+"variable à plusieurs valeurs. (*depuis Picard 2.3.1*)"
+
+#: ../../variables/variables_basic.rst:75
 msgid "**_releasegroup**"
 msgstr "**_releasegroup**"
 
-#: ../../variables/variables_basic.rst:73
+#: ../../variables/variables_basic.rst:77
 msgid ""
 "Release Group Title which is typically the same as the Album Title, but can be "
 "different."
@@ -194,19 +206,19 @@ msgstr ""
 "Le titre du groupe de versions qui est généralement le même que le titre de "
 "l'album, mais peut être différent."
 
-#: ../../variables/variables_basic.rst:75
+#: ../../variables/variables_basic.rst:79
 msgid "**_releasegroupcomment**"
 msgstr "**_releasegroupcomment**"
 
-#: ../../variables/variables_basic.rst:77
+#: ../../variables/variables_basic.rst:81
 msgid "Release Group disambiguation comment."
 msgstr "Le commentaire d'homonymie pour le groupe de version."
 
-#: ../../variables/variables_basic.rst:79
+#: ../../variables/variables_basic.rst:83
 msgid "**_releasegroup_firstreleasedate**"
 msgstr "**_releasegroup_firstreleasedate**"
 
-#: ../../variables/variables_basic.rst:81
+#: ../../variables/variables_basic.rst:85
 msgid ""
 "The date of the earliest release in the Release Group in the format YYYY-MM-DD. "
 "This is intended to provide, for example, the release date of the vinyl version "
@@ -216,18 +228,18 @@ msgstr ""
 "JJ. Ceci est destiné à fournir, par exemple, la date de sortie de la version "
 "vinyle de ce que vous avez sur CD. (*Depuis Picard 2.6*)"
 
-#: ../../variables/variables_basic.rst:85
+#: ../../variables/variables_basic.rst:89
 msgid ""
 "This is the same information provided by default in the ``originaldate`` tag."
 msgstr ""
 "Ce sont les mêmes informations fournies par défaut dans la balise "
 "``originaldate``."
 
-#: ../../variables/variables_basic.rst:87
+#: ../../variables/variables_basic.rst:91
 msgid "**_releaselanguage**"
 msgstr "**_releaselanguage**"
 
-#: ../../variables/variables_basic.rst:89
+#: ../../variables/variables_basic.rst:93
 msgid ""
 "Release Language as per `ISO 639-3 <https://en.wikipedia.org/wiki/ISO_639-3>`_. "
 "(*since Picard 0.10*)"
@@ -235,11 +247,11 @@ msgstr ""
 "La langue de la version selon `ISO 639-3 <https://fr.wikipedia.org/wiki/"
 "ISO_639-3>`_. (*depuis Picard 0,10*)"
 
-#: ../../variables/variables_basic.rst:93
+#: ../../variables/variables_basic.rst:97
 msgid "**_secondaryreleasetype**"
 msgstr "**_secondaryreleasetype**"
 
-#: ../../variables/variables_basic.rst:95
+#: ../../variables/variables_basic.rst:99
 msgid ""
 "Zero or more Release Group Secondary types (i.e.: audiobook, compilation, dj-"
 "mix, interview, live, mixtape/street, remix, soundtrack, or spokenword)."
@@ -248,11 +260,11 @@ msgstr ""
 "livre audio, compilation, DJ-mix, interview, live, mixtape / street, remix, "
 "bande sonore ou speechword)."
 
-#: ../../variables/variables_basic.rst:97
+#: ../../variables/variables_basic.rst:101
 msgid "**_totalalbumtracks**"
 msgstr "**_totalalbumtracks**"
 
-#: ../../variables/variables_basic.rst:99
+#: ../../variables/variables_basic.rst:103
 msgid "The total number of tracks across all discs of this release."
 msgstr "Le nombre total de pistes sur tous les disques de cette version."
 

--- a/epub.rst
+++ b/epub.rst
@@ -85,6 +85,7 @@ plugins and tutorials are provided when available rather than trying to reproduc
 
    tutorials/naming_script
    tutorials/acoustid
+   tutorials/multiple_release_countries
 
 
 .. toctree::

--- a/index.rst
+++ b/index.rst
@@ -85,6 +85,7 @@ plugins and tutorials are provided when available rather than trying to reproduc
 
    tutorials/naming_script
    tutorials/acoustid
+   tutorials/multiple_release_countries
 
 
 .. toctree::

--- a/tutorials/acoustid.rst
+++ b/tutorials/acoustid.rst
@@ -77,3 +77,11 @@ after submission, the AcoustID should be available.
 
 .. Was there a fingerprint generated for this file? Use the "Fingerprint" column for this. If a fingerprint was generated a fingerprint icon should be displayed in this column.
 .. Was there any related error message in Help > View Debug/Error Log.
+
+.. raw:: latex
+
+   \clearpage
+
+..   \pagebreak
+..   \newpage
+..   \clearpage

--- a/tutorials/multiple_release_countries.rst
+++ b/tutorials/multiple_release_countries.rst
@@ -5,8 +5,8 @@ Handling of :index:`multiple release countries <multiple release countries, rele
 
 .. From https://community.metabrainz.org/t/handling-of-multiple-release-countries-with-picard-2-3-1/465485
 
-There has been quite some debate about some digital releases with a really long list of release countries added. Independent on your stand on this matter,
-this has shown that there are some issues with how these releases are handled by Picard.
+Some releases, especially digital releases, can have a very long list of release countries, sometimes listing all of the world's countries except for a few
+where the release is not officially available. Picard offers some tools to handle this.
 
 Let’s take the release **Bleach**, by Nirvana (MusicBrainz release
 `adab3feb-1822-4d27-a997-db7d6c9688c0 <https://musicbrainz.org/release/adab3feb-1822-4d27-a997-db7d6c9688c0>`_) as an example.
@@ -19,7 +19,7 @@ returned as the country for the release. If there were multiple release events, 
 Using preferred release countries
 ==================================
 
-The first improvement was automatic if you configured preferred release countries in :menuselection:`"Options --> Metadata --> Preferred Releases"`.
+If you configure preferred release countries in :menuselection:`"Options --> Metadata --> Preferred Releases"`.
 Picard will use the first country from the preferred release countries that is also in the list of release events. So if you have configured
 preferred release countries to be Europe, Canada, Germany and UK, for our example that would mean the ``releasecountry`` tag gets set to Canada.
 
@@ -71,7 +71,8 @@ such as in the following script:
    $if($eq(%releasecountry%,XW),$set(releasecountry,[Worldwide]))
    $if($eq(%releasecountry%,XG),$set(releasecountry,DDR))
 
-Ideally, someone will add some helper functions for this, such as a ``$countryname()`` function that could be used to easily convert the code into a readable name.
+A change has been submitted to Picard to add a ``$countryname()`` function to easily convert the code into a readable name; however this is not scheduled for
+release until Picard v2.7.
 
 .. raw:: latex
 

--- a/tutorials/multiple_release_countries.rst
+++ b/tutorials/multiple_release_countries.rst
@@ -8,12 +8,12 @@ Handling of :index:`multiple release countries <multiple release countries, rele
 There has been quite some debate about some digital releases with a really long list of release countries added. Independent on your stand on this matter,
 this has shown that there are some issues with how these releases are handled by Picard.
 
-Let’s take the **Live at the Sydney Opera House, Official release by Joe Bonamassa, 2019-10-25** (MusicBrainz release
-`ac3ab901-7da8-480b-a0ab-217ef9f3d9c3 <https://musicbrainz.org/release/ac3ab901-7da8-480b-a0ab-217ef9f3d9c3>`_) as an example.
+Let’s take the release **Bleach**, by Nirvana (MusicBrainz release
+`adab3feb-1822-4d27-a997-db7d6c9688c0 <https://musicbrainz.org/release/adab3feb-1822-4d27-a997-db7d6c9688c0>`_) as an example.
 
 By default Picard will write a single ``releasecountry`` tag to the files. Prior to v2.3.1, Picard had been populating the tag with what the MusicBrainz server
 returned as the country for the release. If there were multiple release events, this country field was just filled with the first one in alphabetical order
-(Algeria in our example). Picard v2.3.1 introduced some options to better handle this.
+(Afghanistan in our example). Picard v2.3.1 introduced some options to better handle this.
 
 
 Using preferred release countries
@@ -21,7 +21,7 @@ Using preferred release countries
 
 The first improvement was automatic if you configured preferred release countries in :menuselection:`"Options --> Metadata --> Preferred Releases"`.
 Picard will use the first country from the preferred release countries that is also in the list of release events. So if you have configured
-preferred release countries to be Europe, Germany and UK, for our example that would mean the ``releasecountry`` tag gets set to Germany.
+preferred release countries to be Europe, Canada, Germany and UK, for our example that would mean the ``releasecountry`` tag gets set to Canada.
 
 
 Using scripting to set a different country

--- a/tutorials/multiple_release_countries.rst
+++ b/tutorials/multiple_release_countries.rst
@@ -1,0 +1,82 @@
+.. MusicBrainz Picard Documentation Project
+
+Handling of :index:`multiple release countries <multiple release countries, release countries; multiple>`
+-----------------------------------------------------------------------------------------------------------
+
+.. From https://community.metabrainz.org/t/handling-of-multiple-release-countries-with-picard-2-3-1/465485
+
+There has been quite some debate about some digital releases with a really long list of release countries added. Independent on your stand on this matter,
+this has shown that there are some issues with how these releases are handled by Picard.
+
+Let’s take the **Live at the Sydney Opera House, Official release by Joe Bonamassa, 2019-10-25** (MusicBrainz release
+`ac3ab901-7da8-480b-a0ab-217ef9f3d9c3 <https://musicbrainz.org/release/ac3ab901-7da8-480b-a0ab-217ef9f3d9c3>`_) as an example.
+
+By default Picard will write a single ``releasecountry`` tag to the files. Prior to v2.3.1, Picard had been populating the tag with what the MusicBrainz server
+returned as the country for the release. If there were multiple release events, this country field was just filled with the first one in alphabetical order
+(Algeria in our example). Picard v2.3.1 introduced some options to better handle this.
+
+
+Using preferred release countries
+==================================
+
+The first improvement was automatic if you configured preferred release countries in :menuselection:`"Options --> Metadata --> Preferred Releases"`.
+Picard will use the first country from the preferred release countries that is also in the list of release events. So if you have configured
+preferred release countries to be Europe, Germany and UK, for our example that would mean the ``releasecountry`` tag gets set to Germany.
+
+
+Using scripting to set a different country
+==============================================
+
+Picard v2.3.1 also added a new variable ``%_releasecountries%``, which provides the complete list of release countries for a release as a multi-value variable.
+You can use this to set different values for the ``releasecountry`` tag.
+
+For example, the following script would set it to "\[International\]" if there are 10 or more release countries:
+
+.. code-block:: taggerscript
+
+   $if($gte($lenmulti(%_releasecountries%),10),$set(releasecountry,[International]))
+
+Of course you can adjust the count and the replacement text to your liking. You can also choose to save the entire list instead of just a single country to
+this tag using the script:
+
+.. code-block:: taggerscript
+
+   $setmulti(releasecountry,%_releasecountries%)
+
+Perhaps you prefer to limit this list to the first few entries. The following example just uses the first 6 countries:
+
+.. code-block:: taggerscript
+
+   $setmulti(releasecountry,$slice(%_releasecountries%,0,6))
+
+
+What’s missing?
+================
+
+Countries are currently written to the tags as their ISO 3166-1 country code, with some special values added for historical countries and things like \[Europe\]
+or \[Worldwide\]. These codes are not always easily recognizable or obvious, such as "DZ" for Algeria or "DE" for Germany. You can of course use scripting to
+make these more readable.  For example, if you want to see "United Kingdom" instead of "GB" in this tag use:
+
+.. code-block:: taggerscript
+
+   $if($eq(%releasecountry%,GB),$set(releasecountry,United Kingdom))
+
+This might work if you deal only with a couple of countries in your collection, or you just want to handle some special cases like using "Europe" instead of "XE"
+such as in the following script:
+
+.. code-block:: taggerscript
+
+   $if($eq(%releasecountry%,XE),$set(releasecountry,Europe))
+   $if($eq(%releasecountry%,XU),$set(releasecountry,[Unknown]))
+   $if($eq(%releasecountry%,XW),$set(releasecountry,[Worldwide]))
+   $if($eq(%releasecountry%,XG),$set(releasecountry,DDR))
+
+Ideally, someone will add some helper functions for this, such as a ``$countryname()`` function that could be used to easily convert the code into a readable name.
+
+.. raw:: latex
+
+   \clearpage
+
+..   \pagebreak
+..   \newpage
+..   \clearpage

--- a/tutorials/tutorials.rst
+++ b/tutorials/tutorials.rst
@@ -8,3 +8,4 @@ Tutorials
 
    naming_script
    acoustid
+   multiple_release_countries

--- a/variables/variables_basic.rst
+++ b/variables/variables_basic.rst
@@ -60,10 +60,6 @@ These variables are populated from MusicBrainz data for most releases, without a
 
    The date of the earliest recording for a track in the format YYYY-MM-DD.  (*Since Picard 2.6*)
 
-**_release_countries**
-
-    This provides the complete list of release countries for the release as a multi-value variable. (*since Picard 2.3.1*)
-
 **_releaseannotation**
 
    The annotation comment for the release. (*since Picard 2.6*)
@@ -71,6 +67,10 @@ These variables are populated from MusicBrainz data for most releases, without a
 **_releasecomment**
 
     Release disambiguation comment. (*since Picard 0.15*)
+
+**_releasecountries**
+
+    This provides the complete list of release countries for the release as a multi-value variable. (*since Picard 2.3.1*)
 
 **_releasegroup**
 

--- a/variables/variables_basic.rst
+++ b/variables/variables_basic.rst
@@ -60,6 +60,10 @@ These variables are populated from MusicBrainz data for most releases, without a
 
    The date of the earliest recording for a track in the format YYYY-MM-DD.  (*Since Picard 2.6*)
 
+**_release_countries**
+
+    This provides the complete list of release countries for the release as a multi-value variable. (*since Picard 2.3.1*)
+
 **_releaseannotation**
 
    The annotation comment for the release. (*since Picard 2.6*)


### PR DESCRIPTION
<!--
    Thank-you for submitting a pull request. Your effort and input is appreciated.

    Please use this template to help us review your change. Not everything is
    required for every change, so please feel free to omit any sections that
    are not relevant to your change.

    Also, please ensure that you've reviewed the guidelines in CONTRIBUTING.md.
-->

### Summary

This is a…

- [ ] Correction
- [x] Addition
- [ ] Restructuring
- [ ] Minor / simple change (like a typo)
- [ ] Other

### Reason for the Change

A new `_release_countries` variable was added in Picard v2.3.1 but never included in the documentation.

### Description of the Change

Added `_releasecountries` to the list of variables provided, and add a tutorial (originally posted by outsidecontext in the forums) explaining how this could be used.

### Additional Action Required

Once the final wording has been approved, the French translation files will need to be updated prior to merging this PR.
