### PR TITLE
Add information about the use of unicode characters in scripts.

### DIFF
--- a/config/options_filerenaming_editor.rst
+++ b/config/options_filerenaming_editor.rst
@@ -32,11 +32,12 @@ The editor screen has the following sections:
    Below the title is an edit box section containing the :index:`formatting string <scripts; file naming>` of the
    selected script. This tells Picard what the new name of the file and its containing directories should be in
    terms of various metadata values. The formatting string is generally referred to as a "file naming script", and
-   is in :doc:`Picard's scripting language <../extending/scripting>` where dark blue text starting with a '$' is a
-   :doc:`function name <../functions/list_by_type>` and names in light blue within '%' signs are Picard's
-   :doc:`tag and variable names <../variables/variables>`. Hovering your mouse pointer over one of the highlighted
-   entries will display help information about the entry if available, and the "Show help tooltips" option
-   is enabled.
+   is in :doc:`Picard's scripting language <../extending/scripting>`.
+
+   The script editor automatically highlights the elements of the script, including
+   :doc:`function names <../functions/list_by_type>` and :doc:`tag and variable names <../variables/variables>`.
+   Hovering your mouse pointer over one of the highlighted entries will display help information about the
+   entry if available.
 
    Unicode characters can be entered into the script using the format ``\uXXXX`` where "XXXX" is the hexadecimal
    value of the unicode character.  It is not recommended to include unicode characters in the directory or filename.

--- a/config/options_filerenaming_editor.rst
+++ b/config/options_filerenaming_editor.rst
@@ -38,6 +38,9 @@ The editor screen has the following sections:
    entries will display help information about the entry if available, and the "Show help tooltips" option
    is enabled.
 
+   Unicode characters can be entered into the script using the format ``\uXXXX`` where "XXXX" is the hexadecimal
+   value of the unicode character.  It is not recommended to include unicode characters in the directory or filename.
+
    The use of a '/' in the formatting string separates the output directory from the file name. The formatting string
    is allowed to contain any number of '/' characters. Everything before the last '/' is the directory location, and
    everything after the last '/' becomes the file's name.

--- a/config/options_scripting.rst
+++ b/config/options_scripting.rst
@@ -16,10 +16,9 @@ the content of the selected script shown in the right-hand column.  This section
 add, remove and reorder the scripts, enable or disable individual scripts, as well as edit the
 currently selected script.
 
-The script editor automatically highlights the elements of the script, where dark blue text
-starting with a '$' is a :doc:`function name <../functions/list_by_type>` and names in light blue
-within '%' signs are Picard's :doc:`tag and variable names <../variables/variables>`. Hovering
-your mouse pointer over one of the highlighted entries will display help information about the
+The script editor automatically highlights the elements of the script, including
+:doc:`function names <../functions/list_by_type>` and :doc:`tag and variable names <../variables/variables>`.
+Hovering your mouse pointer over one of the highlighted entries will display help information about the
 entry if available.
 
 Unicode characters can be entered into the script using the format ``\uXXXX`` where "XXXX" is

--- a/config/options_scripting.rst
+++ b/config/options_scripting.rst
@@ -16,6 +16,15 @@ the content of the selected script shown in the right-hand column.  This section
 add, remove and reorder the scripts, enable or disable individual scripts, as well as edit the
 currently selected script.
 
+The script editor automatically highlights the elements of the script, where dark blue text
+starting with a '$' is a :doc:`function name <../functions/list_by_type>` and names in light blue
+within '%' signs are Picard's :doc:`tag and variable names <../variables/variables>`. Hovering
+your mouse pointer over one of the highlighted entries will display help information about the
+entry if available.
+
+Unicode characters can be entered into the script using the format ``\uXXXX`` where "XXXX" is
+the hexadecimal value of the unicode character.
+
 When the checkbox beside the script is checked, that script will be executed automatically, once
 for each track in the release, when Picard retrieves information for a release from the MusicBrainz
 website.  If the checkbox is left unchecked, then the script will not be executed automatically.


### PR DESCRIPTION
<!--
    Thank-you for submitting a pull request. Your effort and input is appreciated.

    Please use this template to help us review your change. Not everything is
    required for every change, so please feel free to omit any sections that
    are not relevant to your change.

    Also, please ensure that you've reviewed the guidelines in CONTRIBUTING.md.
-->

### Summary

This is a…

- [ ] Correction
- [x] Addition
- [ ] Restructuring
- [ ] Minor / simple change (like a typo)
- [ ] Other

### Reason for the Change

There was no documentation regrading the use of unicode characters in script.

### Description of the Change

Add information about entering unicode characters into scripts.  Also add information about highlighting and tooltips to tagging script documentation.

### Additional Action Required

Translation.
