### PR TITLE
Add note about using "Move additional files" to also move subdirectories

### DIFF
--- a/_locale/gettext/config/options_filerenaming.pot
+++ b/_locale/gettext/config/options_filerenaming.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: MusicBrainz Picard v2.6.3\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-08-12 09:27-0600\n"
+"POT-Creation-Date: 2021-09-12 09:56-0600\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -36,74 +36,78 @@ msgstr ""
 msgid "If this option is left unchecked, then Picard will leave the files in the same directory when they are saved."
 msgstr ""
 
-#: ../../config/options_filerenaming.rst:21
-msgid "Note that the \"Rename Files\" and \"Move Files\" options are independent of one another. \"Rename Files\" refers to Picard changing file names, typically based on artist and track names. \"Move Files\" refers to Picard moving files to new directories, based on a specified parent directory and subdirectories, typically based on album artist name and release title. However, they both use the same \"file naming string\". \"Move files\" uses the portion up until the last '/'. \"Rename files\" uses the portion after the last '/'."
-msgstr ""
-
-#: ../../config/options_filerenaming.rst:28
-msgid "**Destination directory**"
+#: ../../config/options_filerenaming.rst:23
+msgid "The \"Rename Files\" and \"Move Files\" options are independent of one another. \"Rename Files\" refers to Picard changing file names, typically based on artist and track names. \"Move Files\" refers to Picard moving files to new directories, based on a specified parent directory and subdirectories, typically based on album artist name and release title. However, they both use the same \"file naming string\". \"Move files\" uses the portion up until the last '/'. \"Rename files\" uses the portion after the last '/'."
 msgstr ""
 
 #: ../../config/options_filerenaming.rst:30
+msgid "**Destination directory**"
+msgstr ""
+
+#: ../../config/options_filerenaming.rst:32
 msgid "This specifies the destination parent directory to which files are moved when they are saved, if the \"Move files when saving\" option is selected.  If you use the directory \".\" the files will be moved relative to their current location. If they are already in some sort of directory structure, this will probably not do what you want!"
 msgstr ""
 
-#: ../../config/options_filerenaming.rst:35
+#: ../../config/options_filerenaming.rst:37
 msgid "**Move additional files**"
 msgstr ""
 
-#: ../../config/options_filerenaming.rst:37
+#: ../../config/options_filerenaming.rst:39
 msgid "Enter patterns that match any other files you want Picard to move when saving music files (e.g.: \"Folder.jpg\", \"\\*.png\", \"\\*.cue\", \"\\*.log\"). Patterns are separated by spaces. When these additional files are moved they will end up in the release directory with your music files. In a pattern, the '\\*' character matches zero or more characters. Other text, like \".jpg\", matches those exact characters. Thus \"\\*.jpg\" matches \"cover.jpg\", \"liner.jpg\", \"a.jpg\", and \".jpg\", but not \"nomatch.jpg2\"."
 msgstr ""
 
-#: ../../config/options_filerenaming.rst:43
+#: ../../config/options_filerenaming.rst:47
+msgid "This option can also be used to move subdirectories to the new release directory.  This is done by specifying the name of the subdirectory in the list of files to be moved. For example, if your album folders have a subfolder called \"Artwork\", \"covers\" or \"scans\" that contains additional image files that you also want to move to the new release directory, simply add \"artwork\", \"covers\" and \"scans\" to the list of additional file matching patterns."
+msgstr ""
+
+#: ../../config/options_filerenaming.rst:53
 msgid "**Delete empty directories**"
 msgstr ""
 
-#: ../../config/options_filerenaming.rst:45
+#: ../../config/options_filerenaming.rst:55
 msgid "When selected, Picard will remove directories that have become empty once a move is completed. Leave this unchecked if you want Picard to leave the source directory structure unchanged. Checking this box may be convenient if you are using the \"move files\" option to organize your work. An empty directory has no more work for you to do, and deleting the directory makes that clear."
 msgstr ""
 
-#: ../../config/options_filerenaming.rst:50
+#: ../../config/options_filerenaming.rst:60
 msgid "**Rename files when saving**"
 msgstr ""
 
-#: ../../config/options_filerenaming.rst:52
+#: ../../config/options_filerenaming.rst:62
 msgid "Select this option to let Picard change the file and directory names of your files when it saves them, in order to make the file and directory names consistent with the new metadata."
 msgstr ""
 
-#: ../../config/options_filerenaming.rst:55
+#: ../../config/options_filerenaming.rst:65
 msgid "**Replace non-ASCII characters**"
 msgstr ""
 
-#: ../../config/options_filerenaming.rst:57
+#: ../../config/options_filerenaming.rst:67
 msgid "Select this option to replace non-ASCII characters with their ASCII equivalent (e.g.: 'á', 'ä' and 'ǎ' with 'a'; 'é', 'ě' and 'ë' with 'e'; 'æ' with \"ae\"). More information regarding ASCII characters can be found on `Wikipedia <https://en.wikipedia.org/wiki/ASCII>`_."
 msgstr ""
 
-#: ../../config/options_filerenaming.rst:61
+#: ../../config/options_filerenaming.rst:71
 msgid "**Windows compatibility**"
 msgstr ""
 
-#: ../../config/options_filerenaming.rst:63
+#: ../../config/options_filerenaming.rst:73
 msgid "This option tells Picard to replace all Windows-incompatible characters with an underscore. This is enabled by default on Windows systems, with no option to disable."
 msgstr ""
 
-#: ../../config/options_filerenaming.rst:66
+#: ../../config/options_filerenaming.rst:76
 msgid "**Name files like this**"
 msgstr ""
 
-#: ../../config/options_filerenaming.rst:68
+#: ../../config/options_filerenaming.rst:78
 msgid "An edit box that contains a :index:`formatting string <scripts; file naming>` that tells Picard what the new name of the file and its containing directories should be in terms of various metadata values. The formatting string is in :doc:`Picard's scripting language <../extending/scripting>` where dark blue text starting with a '$' is a :doc:`function name <../functions/list_by_type>` and names in light blue within '%' signs are Picard's :doc:`tag and variable names <../variables/variables>`, and is generally referred to as a \"file naming script\". Note that the use of a '/' in the formatting string separates the output directory from the file name. The formatting string is allowed to contain any number of '/' characters. Everything before the last '/' is the directory location, and everything after the last '/' becomes the file's name."
 msgstr ""
 
-#: ../../config/options_filerenaming.rst:77
+#: ../../config/options_filerenaming.rst:87
 msgid "There is only one file naming script defined in a user’s settings, although it can vary from a simple one-line script such as ``%album%/%title%`` to a very complex script using different file naming formats based on different criteria. In all cases, the files will be saved using the text output by the script."
 msgstr ""
 
-#: ../../config/options_filerenaming.rst:81
+#: ../../config/options_filerenaming.rst:91
 msgid "Scripts are often discussed in the `MetaBrainz Community Forum <https://community.metabrainz.org/>`_, and there is a thread specific to `file naming and script snippets <https://community.metabrainz.org/t/repository-for-neat-file-name-string-patterns-and-tagger-script-snippets/2786/>`_."
 msgstr ""
 
-#: ../../config/options_filerenaming.rst:87
+#: ../../config/options_filerenaming.rst:97
 msgid "Any new tags set or tags modified by the file naming script will not be written to the output files' metadata."
 msgstr ""

--- a/config/options_filerenaming.rst
+++ b/config/options_filerenaming.rst
@@ -18,12 +18,14 @@ These options determine how Picard handles files when they are saved with update
    If this option is left unchecked, then Picard will leave the files in the same directory when they
    are saved.
 
-   Note that the "Rename Files" and "Move Files" options are independent of one another. "Rename Files"
-   refers to Picard changing file names, typically based on artist and track names. "Move Files" refers
-   to Picard moving files to new directories, based on a specified parent directory and subdirectories,
-   typically based on album artist name and release title. However, they both use the same "file naming
-   string". "Move files" uses the portion up until the last '/'. "Rename files" uses the portion after
-   the last '/'.
+   .. note::
+
+      The "Rename Files" and "Move Files" options are independent of one another. "Rename Files"
+      refers to Picard changing file names, typically based on artist and track names. "Move Files" refers
+      to Picard moving files to new directories, based on a specified parent directory and subdirectories,
+      typically based on album artist name and release title. However, they both use the same "file naming
+      string". "Move files" uses the portion up until the last '/'. "Rename files" uses the portion after
+      the last '/'.
 
 **Destination directory**
 
@@ -39,6 +41,14 @@ These options determine how Picard handles files when they are saved with update
    files are moved they will end up in the release directory with your music files. In a pattern, the
    '\*' character matches zero or more characters. Other text, like ".jpg", matches those exact
    characters. Thus "\*.jpg" matches "cover.jpg", "liner.jpg", "a.jpg", and ".jpg", but not "nomatch.jpg2".
+
+   .. note::
+
+      This option can also be used to move subdirectories to the new release directory.  This is done by
+      specifying the name of the subdirectory in the list of files to be moved. For example, if your album
+      folders have a subfolder called "Artwork", "covers" or "scans" that contains additional image files
+      that you also want to move to the new release directory, simply add "artwork", "covers" and "scans"
+      to the list of additional file matching patterns.
 
 **Delete empty directories**
 


### PR DESCRIPTION
<!--
    Thank-you for submitting a pull request. Your effort and input is appreciated.

    Please use this template to help us review your change. Not everything is
    required for every change, so please feel free to omit any sections that
    are not relevant to your change.

    Also, please ensure that you've reviewed the guidelines in CONTRIBUTING.md.
-->

### Summary

This is a…

- [ ] Correction
- [x] Addition
- [ ] Restructuring
- [ ] Minor / simple change (like a typo)
- [x] Other

### Reason for the Change

There are often questions about whether Picard can also move subdirectories (e.g. containing additional images, etc.)  when moving files to a new release directory.  It is not clear in the documentation that this is possible.  See the discussion on the [Community Forum](https://community.metabrainz.org/t/can-i-automate-moving-a-subfolder-ie-artwork-when-moving-and-creating-my-new-album-folders/550628).

### Description of the Change

Add information about also moving subdirectores by specifying them in the "Move additional files" option settings.

### Additional Action Required

Translations.
