### PR TITLE
Add note about saving the files before submitting to acousticbrainz

### DIFF
--- a/usage/submit_acousticbrainz.rst
+++ b/usage/submit_acousticbrainz.rst
@@ -16,9 +16,13 @@ from your music files and submitting it to the AcousticBrainz database.
    All information extraction from a music file is performed on your system and only this information is sent to
    AcousticBrainz.  Your actual music files are not transmitted.
 
-To extract the information from an audio file and submit it to AcousticBrainz, simply select the tracks or releases that you
-wish to submit and select the "Submit AcousticBrainz features" command from the "Tools" section of Picard's main menu bar.
-If the files are properly tagged with MusicBrainz identifiers and a valid extraction application has been configured in the
+To extract the information from an audio file and submit it to AcousticBrainz, you must first match your audio files to
+release and track information from the MusicBrainz database and save the files. See the :doc:`retrieve` and :doc:`match`
+sections for more information about retrieving release information and matching audio files to releases.
+
+Once the files have been matched and saved, simply select the tracks or releases that you wish to submit and use the "Submit
+AcousticBrainz features" command from the "Tools" section of Picard's main menu bar. If the files are properly tagged with
+MusicBrainz identifiers and a valid extraction application has been configured in the
 :doc:`AcousticBrainz option settings <../config/options_acousticbrainz>`, then the files will be added to a queue where they
 will be processed in the background.
 


### PR DESCRIPTION
<!--
    Thank-you for submitting a pull request. Your effort and input is appreciated.

    Please use this template to help us review your change. Not everything is
    required for every change, so please feel free to omit any sections that
    are not relevant to your change.

    Also, please ensure that you've reviewed the guidelines in CONTRIBUTING.md.
-->

### Summary

This is a…

- [x] Correction
- [ ] Addition
- [ ] Restructuring
- [ ] Minor / simple change (like a typo)
- [ ] Other

### Reason for the Change

Changes made in https://github.com/metabrainz/picard/pull/1902 require that the files be matched to MusicBrainz releases and saved before submitting to AcousticBrainz.

### Description of the Change

Add explanation of the new requirement to the documentation.

### Additional Action Required

Translations.